### PR TITLE
Enable travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install: true
 cache:
   directories:
   - $HOME/.m2
-script: mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V
+script: cd registration && mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install: true
 cache:
   directories:
   - $HOME/.m2
-script: cd registration && mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V && cd ..
+script: mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk: openjdk8
+install: true
+cache:
+  directories:
+  - $HOME/.m2
+script: mvn install -DskipTests=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -B -V

--- a/registration/pom.xml
+++ b/registration/pom.xml
@@ -54,7 +54,7 @@
 		<jackson.version>2.8.8</jackson.version>
 		<jackson.mapper.asl.version>1.7.1</jackson.mapper.asl.version>
 
-		<mosip.core.kernel.version>1.0.6</mosip.core.kernel.version>
+		<mosip.core.kernel.version>1.0.6-SNAPSHOT</mosip.core.kernel.version>
 		<!-- Derby Version -->
 		<apache.derby.version>10.13.1.1</apache.derby.version>
 

--- a/registration/pom.xml
+++ b/registration/pom.xml
@@ -251,7 +251,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.9.10.3</version>
+				<version>2.9.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/registration/pom.xml
+++ b/registration/pom.xml
@@ -251,7 +251,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.9.4</version>
+				<version>2.9.10.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/registration/pom.xml
+++ b/registration/pom.xml
@@ -54,7 +54,7 @@
 		<jackson.version>2.8.8</jackson.version>
 		<jackson.mapper.asl.version>1.7.1</jackson.mapper.asl.version>
 
-		<mosip.core.kernel.version>1.0.6-SNAPSHOT</mosip.core.kernel.version>
+		<mosip.core.kernel.version>1.0.6</mosip.core.kernel.version>
 		<!-- Derby Version -->
 		<apache.derby.version>10.13.1.1</apache.derby.version>
 

--- a/registration/registration-libs/src/main/resources/props/mosip-application.properties
+++ b/registration/registration-libs/src/main/resources/props/mosip-application.properties
@@ -1,5 +1,5 @@
-#1.0.6-SNAPSHOT
-#Tue Jan 21 21:14:41 IST 2020
+#1.0.7-SNAPSHOT
+#Thu Mar 19 14:47:10 IST 2020
 mosip.reg.client.url=https\://devops.mosip.io/artifactory/libs-snapshot/io/mosip/registration/registration-client/
 mosip.reg.env=qa
 mosip.reg.version=1.0.7-SNAPSHOT
@@ -7,10 +7,10 @@ mosip.reg.mdm.server.port=8080
 mosip.reg.logpath=../logs
 mosip.reg.packetstorepath=../PacketStore
 mosip.reg.healthcheck.url=https\://qa.mosip.io/v1/authmanager/actuator/health
-mosip.reg.rollback.path=../BackUp
 mosip.reg.db.key=bW9zaXAxMjM0NQ\=\=
+mosip.reg.rollback.path=../BackUp
 mosip.reg.cerpath=/cer//mosip_cer.cer
-mosip.reg.xml.file.url=https\://devops.mosip.io/artifactory/libs-snapshot/io/mosip/registration/registration-client/maven-metadata.xml
 mosip.reg.dbpath=db/reg
+mosip.reg.xml.file.url=https\://devops.mosip.io/artifactory/libs-snapshot/io/mosip/registration/registration-client/maven-metadata.xml
 mosip.reg.app.key=bBQX230Wskq6XpoZ1c+Ep1D+znxfT89NxLQ7P4KFkc4\=
 mosip.reg.client.tpm.availability=N

--- a/registration/registration-libs/src/main/resources/props/mosip-application.properties
+++ b/registration/registration-libs/src/main/resources/props/mosip-application.properties
@@ -1,5 +1,5 @@
-#1.0.7-SNAPSHOT
-#Thu Mar 19 14:47:10 IST 2020
+#1.0.6-SNAPSHOT
+#Tue Jan 21 21:14:41 IST 2020
 mosip.reg.client.url=https\://devops.mosip.io/artifactory/libs-snapshot/io/mosip/registration/registration-client/
 mosip.reg.env=qa
 mosip.reg.version=1.0.7-SNAPSHOT
@@ -7,10 +7,10 @@ mosip.reg.mdm.server.port=8080
 mosip.reg.logpath=../logs
 mosip.reg.packetstorepath=../PacketStore
 mosip.reg.healthcheck.url=https\://qa.mosip.io/v1/authmanager/actuator/health
-mosip.reg.db.key=bW9zaXAxMjM0NQ\=\=
 mosip.reg.rollback.path=../BackUp
+mosip.reg.db.key=bW9zaXAxMjM0NQ\=\=
 mosip.reg.cerpath=/cer//mosip_cer.cer
-mosip.reg.dbpath=db/reg
 mosip.reg.xml.file.url=https\://devops.mosip.io/artifactory/libs-snapshot/io/mosip/registration/registration-client/maven-metadata.xml
+mosip.reg.dbpath=db/reg
 mosip.reg.app.key=bBQX230Wskq6XpoZ1c+Ep1D+znxfT89NxLQ7P4KFkc4\=
 mosip.reg.client.tpm.availability=N

--- a/registration/registration-services/pom.xml
+++ b/registration/registration-services/pom.xml
@@ -314,6 +314,13 @@
 			<groupId>com.cronutils</groupId>
 			<artifactId>cron-utils</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.oracle</groupId>
+			<artifactId>javafx</artifactId>
+			<version>${javafx.version}</version>
+			<systemPath>${project.basedir}/../lib/jfxrt.jar</systemPath>
+			<scope>system</scope>
+		</dependency>
 
 		<!-- __https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 		<dependency>


### PR DESCRIPTION
1) Include jfxt jar in the git so Travis can build. This is a temporary fix. We have to remove the dependencies of jfxt in the service layer.
2) Travis to skip test cases.
3) Fix the security alert for jackson databind 