### PR TITLE
MOSIP- 526 : Fixed Job Configuartions

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
@@ -927,6 +927,14 @@ public class RegistrationConstants {
 	public static final String JOB_TRIGGER_MIS_FIRED = "Trigger Mis-Fired";
 	public static final String JOB_EXECUTION_REJECTED = "Execution Rejected";
 	public static final String RETRIEVED_PRE_REG_ID = "Retrieved Pre Registration";
+	
+	public static final String offlineJobs = "mosip.registration.jobs.offline";
+	public static final String unTaggedJobs ="mosip.registration.jobs.unTagged";
+	public static final String restartableJobs ="mosip.registration.jobs.restart";
+	
+//	public static final String offlineJobs = "DEL_J00013,RDJ_J00010,ADJ_J00012,PVS_J00015";
+//	public static final String unTaggedJobs ="PDS_J00003";
+//	public static final String restartableJobs ="RCS_J00005";
 
 	public static final String JOB_TRIGGER_POINT_SYSTEM = "System";
 	public static final String JOB_TRIGGER_POINT_USER = "User";

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/jobs/JobConfigurationServiceTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/jobs/JobConfigurationServiceTest.java
@@ -133,6 +133,13 @@ public class JobConfigurationServiceTest {
 		applicationMap.put(RegistrationConstants.SYNC_TRANSACTION_NO_OF_DAYS_LIMIT, "5");
 		applicationMap.put(RegistrationConstants.SYNC_DATA_FREQ, "0 0 11 * * ?");
 
+		applicationMap.put(RegistrationConstants.offlineJobs, "DEL_J00013,RDJ_J00010,ADJ_J00012,PVS_J00015");
+
+
+		applicationMap.put(RegistrationConstants.unTaggedJobs, "PDS_J00003");
+
+		applicationMap.put(RegistrationConstants.restartableJobs, "RCS_J00005");
+
 		// PowerMockito.mockStatic(io.mosip.registration.context.ApplicationContext.class);
 		// when(io.mosip.registration.context.ApplicationContext.map()).thenReturn(applicationMap);
 		// PowerMockito.mockStatic(io.mosip.registration.context.ApplicationContext.class);
@@ -353,6 +360,7 @@ public class JobConfigurationServiceTest {
 		PowerMockito.mockStatic(BaseJob.class);
 
 		Mockito.when(BaseJob.getCompletedJobMap()).thenReturn(completedJobMap);
+		
 		Assert.assertNotNull(jobConfigurationService.isRestart().getSuccessResponseDTO());
 
 	}
@@ -395,17 +403,20 @@ public class JobConfigurationServiceTest {
 
 	@Test
 	public void getOfflineJobsTest() {
+		initiateJobTest();
 		Assert.assertNotNull(jobConfigurationService.getOfflineJobs());
 	}
 
 	@Test
 	public void getUnTaggedJobsTest() {
+		initiateJobTest();
 		Assert.assertNotNull(jobConfigurationService.getUnTaggedJobs());
 	}
 
 	@Test
 	public void startSchedulerExcepTest() {
 
+		initiateJobTest();
 		Mockito.doThrow(RuntimeException.class).when(schedulerFactoryBean).start();
 
 		Assert.assertNotNull(jobConfigurationService.startScheduler().getErrorResponseDTOs());


### PR DESCRIPTION
This is because of sync incossistent.

The background issue of auth failure is Password verification, because of SALT was getting null due to User Detail Sync.

There were 2 jobs, SALTSync with parent of UserDetailSync, while running salt sync, internally it completes user detail sync first then post success, salt sync will be executed. After that Userdetail sync which was not having any parent job executing independently.

So, the fix will be if any job which was acting as a parent of any job, will not re-executed independently.

Note : Please find below configs which should be added in our environment files : 
#Jobs
#offline jobs, which will be not part of manual sync
#Add by comma (,) separator if to add more jobs
mosip.registration.jobs.offline =DEL_J00013,RDJ_J00010,ADJ_J00012,PVS_J00015

#Untagged jobs, which will be not part of manual sync but only from scheduler
#Add by comma (,) separator if to add more jobs
mosip.registration.jobs.unTagged =PDS_J00003

#restart jobs, which requests application to be restarted post the job success
#Add by comma (,) separator if to add more jobs
mosip.registration.jobs.restart =RCS_J00005
