### PR TITLE
MOS-31275 : Extrnalised batch jobs scheduler as part of configs

### DIFF
--- a/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
@@ -932,6 +932,11 @@ public class RegistrationConstants {
 	public static final String unTaggedJobs ="mosip.registration.jobs.unTagged";
 	public static final String restartableJobs ="mosip.registration.jobs.restart";
 	
+	//Registration batch jobs scheduler : If ‘Y’ or ‘y’ means enabled, else anything as value means disabled
+	public static final String IS_REGISTRATION_JOBS_SCHEDULER_ENABLED ="mosip.registration.jobs.scheduler.enable";
+	
+	
+	
 //	public static final String offlineJobs = "DEL_J00013,RDJ_J00010,ADJ_J00012,PVS_J00015";
 //	public static final String unTaggedJobs ="PDS_J00003";
 //	public static final String restartableJobs ="RCS_J00005";

--- a/registration/registration-services/src/main/java/io/mosip/registration/service/config/impl/JobConfigurationServiceImpl.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/service/config/impl/JobConfigurationServiceImpl.java
@@ -263,7 +263,9 @@ public class JobConfigurationServiceImpl extends BaseService implements JobConfi
 		/* Check Whether Scheduler is running or not */
 		if (isSchedulerRunning()) {
 			return setErrorResponse(responseDTO, RegistrationConstants.SYNC_DATA_PROCESS_ALREADY_STARTED, null);
-		} else {
+		} else if (RegistrationConstants.ENABLE.equalsIgnoreCase(
+				getGlobalConfigValueOf(RegistrationConstants.IS_REGISTRATION_JOBS_SCHEDULER_ENABLED))) {
+
 			try {
 				schedulerFactoryBean.start();
 				isSchedulerRunning = true;
@@ -283,6 +285,10 @@ public class JobConfigurationServiceImpl extends BaseService implements JobConfi
 				setErrorResponse(responseDTO, RegistrationConstants.START_SCHEDULER_ERROR_MESSAGE, null);
 			}
 
+		} else {
+
+			// Configuration was disabled to run the jobs scheduler
+			return setErrorResponse(responseDTO, RegistrationConstants.START_SCHEDULER_ERROR_MESSAGE, null);
 		}
 
 		LOGGER.info(LoggerConstants.BATCH_JOBS_CONFIG_LOGGER_TITLE, RegistrationConstants.APPLICATION_NAME,

--- a/registration/registration-services/src/test/java/io/mosip/registration/test/jobs/JobConfigurationServiceTest.java
+++ b/registration/registration-services/src/test/java/io/mosip/registration/test/jobs/JobConfigurationServiceTest.java
@@ -139,6 +139,8 @@ public class JobConfigurationServiceTest {
 		applicationMap.put(RegistrationConstants.unTaggedJobs, "PDS_J00003");
 
 		applicationMap.put(RegistrationConstants.restartableJobs, "RCS_J00005");
+		
+		applicationMap.put(RegistrationConstants.IS_REGISTRATION_JOBS_SCHEDULER_ENABLED, "Y");
 
 		// PowerMockito.mockStatic(io.mosip.registration.context.ApplicationContext.class);
 		// when(io.mosip.registration.context.ApplicationContext.map()).thenReturn(applicationMap);


### PR DESCRIPTION
Please add the below configuration to configuration properties file

//Registration batch jobs scheduler : If  value ‘Y’ or ‘y’ means enabled, else disabled
mosip.registration.jobs.scheduler.enable = Y
