### PR TITLE
MOSIP-10416

### DIFF
--- a/registration-processor/core-processor/registration-processor-reprocessor-stage/Dockerfile
+++ b/registration-processor/core-processor/registration-processor-reprocessor-stage/Dockerfile
@@ -38,16 +38,22 @@ VOLUME /home/logs
 
 COPY ./target/registration-processor-reprocessor-stage-*.jar registration-processor-reprocessor-stage.jar
 
-CMD if [ "$is_glowroot_env" = "present" ]; then \
+#Below 4 lines is added only as a temporary fix to downloaded the ceylon dependencies for chime scheduler
+#later this chime to be replaced with something else
+CMD apt-get update && apt-get install -y unzip ; \
+    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/regproc-reprocessor-ceylon-cache-repo.zip ; \
+    unzip regproc-reprocessor-ceylon-cache-repo.zip ; \
+    rm -rf regproc-reprocessor-ceylon-cache-repo.zip ; \
+
+    if [ "$is_glowroot_env" = "present" ]; then \
     wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
-    apt-get update && apt-get install -y unzip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
     
     sed -i 's/<service_name>/registration-processor-reprocessor-stage/g' glowroot/glowroot.properties ; \
-    java -jar -javaagent:glowroot/glowroot.jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" registration-processor-reprocessor-stage.jar ; \
+    java -jar -javaagent:glowroot/glowroot.jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -Dceylon.cache.repo=./regproc-reprocessor-ceylon-cache-repo registration-processor-reprocessor-stage.jar ; \
     else \
-    java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" registration-processor-reprocessor-stage.jar ; \
+    java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -Dceylon.cache.repo=./regproc-reprocessor-ceylon-cache-repo registration-processor-reprocessor-stage.jar ; \
     fi
 
 #CMD ["java","-Dspring.cloud.config.label=${spring_config_label_env}","-Dspring.profiles.active=${active_profile_env}","-Dspring.cloud.config.uri=${spring_config_url_env}","-jar","registration-processor-reprocessor-stage.jar"]

--- a/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/reprocessor/stage/ReprocessorStage.java
+++ b/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/reprocessor/stage/ReprocessorStage.java
@@ -121,12 +121,12 @@ public class ReprocessorStage extends MosipVerticleAPIManager {
 
 	public void schedulerResult(AsyncResult<String> res) {
 		if (res.succeeded()) {
-			regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),
+			regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),
 					"", "ReprocessorStage::schedular()::deployed");
 			cronScheduling(vertx);
 		} else {
-			regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),
-					"", "ReprocessorStage::schedular()::deploymemnt failure");
+			regProcLogger.error(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),
+					"", "ReprocessorStage::schedular()::deploymemnt failure " + res.cause());
 		}
 	}
 
@@ -165,13 +165,13 @@ public class ReprocessorStage extends MosipVerticleAPIManager {
 						.put(ReprocessorConstants.DESCRIPTION, timer),
 				ar -> {
 					if (ar.succeeded()) {
-						regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(),
+						regProcLogger.info(LoggerFileConstant.SESSIONID.toString(),
 								LoggerFileConstant.REGISTRATIONID.toString(), "",
 								"ReprocessorStage::schedular()::started");
 					} else {
-						regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(),
+						regProcLogger.error(LoggerFileConstant.SESSIONID.toString(),
 								LoggerFileConstant.REGISTRATIONID.toString(), "",
-								"ReprocessorStage::schedular()::failed");
+								"ReprocessorStage::schedular()::failed " + ar.cause());
 						vertx.close();
 					}
 				});

--- a/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/retry/verticle/constants/ReprocessorConstants.java
+++ b/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/retry/verticle/constants/ReprocessorConstants.java
@@ -8,6 +8,8 @@ public class ReprocessorConstants {
 	
 	/** The Constant USER. */
 	public static final String USER = "MOSIP_SYSTEM";
+	//Based on the below ceylon chime version, the required ceylon dependencies are zipped 
+	//and uploaded to artifactory and downloaded and unzipped while starting the docker container
 	public static final String CEYLON_SCHEDULER = "ceylon:herd.schedule.chime/0.2.0";
 	public static final String TIMER_EVENT= "scheduler:stage_timer";
 	public static final String TYPE = "type";


### PR DESCRIPTION
Reprocessor stage is using chime library for scheduling purpose, this chime library uses ceylon dependencies which was getting downloaded in runtime from internet and since it was taking long time to download, vertx was complaining thread is blocked.

Downloading from internet should be avoided, so as a temporary workaround we have changed the docker file to download the dependencies upfront from the artifactory and then start the application. So while deploying this fix, we should ensure to host the dependencies zip in the local artifactory.

The permanent fix could be to change to a different library instead of chime.

Also few logs are changed from debug to info to understand if the scheduler started successfully.
