### PR TITLE
MOSIP-11260 : Message expiration functionality added to messages sent to ABIS

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/AbisMiddleWareApplication.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/AbisMiddleWareApplication.java
@@ -18,7 +18,8 @@ public class AbisMiddleWareApplication {
                 "io.mosip.registration.processor.packet.storage.config",
                 "io.mosip.registration.processor.core.config",
                 "io.mosip.registration.processor.core.kernel.beans",
-                "io.mosip.registration.processor.stages.config");
+				"io.mosip.registration.processor.stages.config",
+				"io.mosip.registartion.processor.abis.middleware.validators");
 		configApplicationContext.refresh();
 		AbisMiddleWareStage demodedupeStage = configApplicationContext.getBean(AbisMiddleWareStage.class);
 	

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/validators/AppConfigurationsValidator.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/validators/AppConfigurationsValidator.java
@@ -1,0 +1,64 @@
+package io.mosip.registartion.processor.abis.middleware.validators;
+
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import java.util.List;
+
+import io.mosip.registration.processor.abis.queue.dto.AbisQueueDetails;
+import io.mosip.registration.processor.core.exception.RegistrationProcessorCheckedException;
+import io.mosip.registration.processor.packet.storage.utils.Utilities;
+
+/**
+ * All the configuration validations will be done in this class
+ */
+@Component
+public class AppConfigurationsValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AppConfigurationsValidator.class);
+
+    /**
+     * This configuration will be used by reprocessor stage to reprocess the events
+     */
+    @Value("${registration.processor.reprocess.elapse.time}")
+    private long reprocessorElapseTime;
+
+
+    @Value("${registration.processor.bio.dedupe.reprocess.buffer.time}")
+    private long reprocessBufferTime;
+
+    @Autowired
+    private Utilities utility;
+
+    /**
+     * The below method will be called by spring once the context is initialized or refreshed
+     * @param event Context refreshed event
+     */
+    @EventListener
+    public void validateConfigurations(ContextRefreshedEvent event) {
+        logger.info("ContextRefreshedEvent received");
+        validateReprocessElapseTimeConfig();
+    }
+
+    private void validateReprocessElapseTimeConfig() {
+        try {
+            List<AbisQueueDetails> abisQueueDetails = utility.getAbisQueueDetails();
+            long allowedReprocessTime = reprocessBufferTime;
+            for(AbisQueueDetails abisQueueDetail : abisQueueDetails) {
+                //TTL is multiplied by 2 to compute both Insert and Identify request expiry time
+                allowedReprocessTime += (abisQueueDetail.getInboundMessageTTL() * 2);
+            }
+            if(allowedReprocessTime >= reprocessorElapseTime) {
+                logger.warn("registration.processor.reprocess.elapse.time config {} is invalid," +
+                    " it should should be greater than all the queue expiry put tother with an" +
+                    " additional buffer {}", reprocessorElapseTime, allowedReprocessTime);
+            }
+        } catch (RegistrationProcessorCheckedException e) {
+            logger.error("Abis queue details invalid", e);
+        }
+    }
+}

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/validators/AppConfigurationsValidator.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/validators/AppConfigurationsValidator.java
@@ -52,9 +52,9 @@ public class AppConfigurationsValidator {
                 //TTL is multiplied by 2 to compute both Insert and Identify request expiry time
                 allowedReprocessTime += (abisQueueDetail.getInboundMessageTTL() * 2);
             }
-            if(allowedReprocessTime >= reprocessorElapseTime) {
+            if(reprocessorElapseTime <= allowedReprocessTime) {
                 logger.warn("registration.processor.reprocess.elapse.time config {} is invalid," +
-                    " it should should be greater than all the queue expiry put tother with an" +
+                    " it should should be greater than all the queue expiry put together with an" +
                     " additional buffer {}", reprocessorElapseTime, allowedReprocessTime);
             }
         } catch (RegistrationProcessorCheckedException e) {

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
@@ -97,6 +97,7 @@ public class AbisMiddleWareStageTest {
 	private List<String> abisRefList;
 	private List<AbisRequestDto> abisInsertIdentifyList;
 	private List<MosipQueue> mosipQueueList;
+	private int messageTTL = 0;
 
 	@InjectMocks
 	AbisMiddleWareStage stage = new AbisMiddleWareStage() {
@@ -285,7 +286,7 @@ public class AbisMiddleWareStageTest {
 				.thenReturn(abisIdentifyRequestDtoList);
 
 		// Mockito.when(utility.getInboundOutBoundAddressList()).thenReturn(abisInboundOutBounAddressList);
-
+		messageTTL = 30 * 60;
 	}
 
 	@Test
@@ -398,7 +399,7 @@ public class AbisMiddleWareStageTest {
 		AbisRequestDto abisCommonRequestDto = new AbisRequestDto();
 		abisCommonRequestDto.setRequestType("INSERT");
 		Mockito.when(packetInfoManager.getAbisRequestByRequestId(Mockito.any())).thenReturn(abisCommonRequestDto);
-		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus);
+		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus, messageTTL);
 
 		String sucessfulResponse = "{\"id\":\"mosip.abis.insert\",\"requestId\":\"5b64e806-8d5f-4ba1-b641-0b55cf40c0e1\",\"responsetime\":"
 				+ null + ",\"returnValue\":1,\"failureReason\":null}\r\n"
@@ -409,7 +410,7 @@ public class AbisMiddleWareStageTest {
 		abisCommonRequestDto1.setRequestType("INSERT");
 		abisCommonRequestDto1.setAbisAppCode("Abis1");
 		Mockito.when(packetInfoManager.getAbisRequestByRequestId(Mockito.any())).thenReturn(abisCommonRequestDto1);
-		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus);
+		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus, messageTTL);
 
 	}
 	
@@ -429,7 +430,7 @@ public class AbisMiddleWareStageTest {
 		AbisRequestDto abisCommonRequestDto = new AbisRequestDto();
 		abisCommonRequestDto.setRequestType("IDENTIFY");
 		Mockito.when(packetInfoManager.getAbisRequestByRequestId(Mockito.any())).thenReturn(abisCommonRequestDto);
-		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus);
+		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus, messageTTL);
 
 
 	}
@@ -451,7 +452,7 @@ public class AbisMiddleWareStageTest {
 		abisCommonRequestDto1.setAbisAppCode("Abis1");
 		//Mockito.when(packetInfoManager.getAbisRequestByRequestId(Mockito.any())).thenReturn(abisCommonRequestDto1);
 		Mockito.when(packetInfoManager.getBatchIdByRequestId(Mockito.anyString())).thenReturn(null);
-		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, eventBus1);
+		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, eventBus1, messageTTL);
 
 	}
 
@@ -474,20 +475,20 @@ public class AbisMiddleWareStageTest {
 		AbisRequestDto abisCommonRequestDto1 = new AbisRequestDto();
 		abisCommonRequestDto1.setRequestType("IDENTIFY");
 		Mockito.when(packetInfoManager.getAbisRequestByRequestId(Mockito.any())).thenReturn(abisCommonRequestDto1);
-		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1);
+		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1, messageTTL);
 		// test for identify failed response
 		String identifyFailedResponse = "{\"id\":\"mosip.abis.identify\",\"requestId\":\"8a3effd4-5fba-44e0-8cbb-3083ba098209\",\"responsetime\":"
 				+ null + ",\"returnValue\":2,\"failureReason\":3,\"candidateList\":null}";
 		byteSeq1.setData(identifyFailedResponse.getBytes());
 		amq1.setContent(byteSeq1);
-		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1);
+		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1, messageTTL);
 		// test for identify response - with duplicates
 		String duplicateIdentifySuccessResponse = "{\"id\":\"mosip.abis.identify\",\"requestId\":\"f4b1f6fd-466c-462f-aa8b-c218596542ec\",\"responsetime\":"
 				+ null
 				+ ",\"returnValue\":1,\"failureReason\":null,\"candidateList\":{\"count\":\"1\",\"candidates\":[{\"referenceId\":\"d1070375-0960-4e90-b12c-72ab6186444d\",\"analytics\":null,\"modalities\":null}]}}";
 		byteSeq1.setData(duplicateIdentifySuccessResponse.getBytes());
 		amq1.setContent(byteSeq1);
-		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1);
+		stage.consumerListener(amq1, "abis1_inboundAddress", queue1, evenBus1, messageTTL);
 
 	}
 	
@@ -526,7 +527,7 @@ public class AbisMiddleWareStageTest {
 		PowerMockito.mockStatic(JsonUtil.class);
 		PowerMockito.when(JsonUtil.objectMapperReadValue(response, AbisIdentifyResponseDto.class)).thenReturn(abisIdentifyResponseDto);
 		Mockito.when(packetInfoDao.getRegIdByBioRefId(ArgumentMatchers.any())).thenReturn("Test123");
-		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus);
+		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus, messageTTL);
 	}
 	
 	@Test(expected = RegistrationProcessorCheckedException.class)
@@ -557,6 +558,6 @@ public class AbisMiddleWareStageTest {
 		String response = new String(((ActiveMQBytesMessage) amq).getContent().data);
 		PowerMockito.mockStatic(JsonUtil.class);
 		PowerMockito.when(JsonUtil.readValueWithUnknownProperties(response, AbisIdentifyResponseDto.class)).thenThrow(IOException.class);
-		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus);
+		stage.consumerListener(amq, "abis1_inboundAddress", queue, evenBus, messageTTL);
 	}
 }

--- a/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/ManualVerificationApplication.java
+++ b/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/ManualVerificationApplication.java
@@ -29,7 +29,8 @@ public class ManualVerificationApplication {
 				"io.mosip.kernel.packetmanager.config",
 				"io.mosip.registration.processor.status.config", "io.mosip.registration.processor.rest.client.config",
 				"io.mosip.registration.processor.core.kernel.beans",
-				"io.mosip.registration.processor.packet.storage.config");
+				"io.mosip.registration.processor.packet.storage.config",
+				"io.mosip.registration.processor.manual.verification.validators");
 		configApplicationContext.refresh();
 		ManualVerificationStage manualVerificationStage = configApplicationContext
 				.getBean(ManualVerificationStage.class);

--- a/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/service/impl/ManualVerificationServiceImpl.java
+++ b/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/service/impl/ManualVerificationServiceImpl.java
@@ -149,6 +149,10 @@ public class ManualVerificationServiceImpl implements ManualVerificationService 
 	@Value("${registration.processor.queue.manualverification.request:mosip-to-mv}")
 	private String mvRequestAddress;
 
+	/**Manual verification queue message expiry in seconds, if given 0 then message will never expire*/
+	@Value("${registration.processor.queue.manualverification.request.messageTTL}")
+	private int mvRequestMessageTTL;
+
 	@Value("${packet.default.source}")
 	private String defaultSource;
 
@@ -616,9 +620,9 @@ public class ManualVerificationServiceImpl implements ManualVerificationService 
 
 		ManualAdjudicationRequestDTO mar = prepareManualAdjudicationRequest(mves);
 		if (messageFormat.equalsIgnoreCase(TEXT_MESSAGE))
-			mosipQueueManager.send(queue, JsonUtils.javaObjectToJsonString(mar), mvRequestAddress);
+			mosipQueueManager.send(queue, JsonUtils.javaObjectToJsonString(mar), mvRequestAddress, mvRequestMessageTTL);
 		else
-			mosipQueueManager.send(queue, JsonUtils.javaObjectToJsonString(mar).getBytes(), mvRequestAddress);
+			mosipQueueManager.send(queue, JsonUtils.javaObjectToJsonString(mar).getBytes(), mvRequestAddress, mvRequestMessageTTL);
 		regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),
 				refId, "ManualVerificationServiceImpl::pushRequestToQueue()::entry");
 

--- a/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/validators/AppConfigurationsValidator.java
+++ b/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/validators/AppConfigurationsValidator.java
@@ -1,0 +1,48 @@
+package io.mosip.registration.processor.manual.verification.validators;
+
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+/**
+ * All the configuration validations will be done in this class
+ */
+@Component
+public class AppConfigurationsValidator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AppConfigurationsValidator.class);
+
+    /**
+     * This configuration will be used by reprocessor stage to reprocess the events
+     */
+    @Value("${registration.processor.reprocess.elapse.time}")
+    private long reprocessorElapseTime;
+
+    @Value("${registration.processor.queue.manualverification.request.messageTTL}")
+	private int mvRequestMessageTTL;
+
+    @Value("${registration.processor.manual.verification.reprocess.buffer.time}")
+    private long reprocessBufferTime;
+
+    /**
+     * The below method will be called by spring once the context is initialized or refreshed
+     * @param event Context refreshed event
+     */
+    @EventListener
+    public void validateConfigurations(ContextRefreshedEvent event) {
+        logger.info("ContextRefreshedEvent received");
+        validateReprocessElapseTimeConfig();
+    }
+
+    private void validateReprocessElapseTimeConfig() {
+        long allowedReprocessTime = mvRequestMessageTTL + reprocessBufferTime;
+        if(reprocessorElapseTime <= allowedReprocessTime) {
+            logger.warn("registration.processor.reprocess.elapse.time config {} is invalid," +
+                " it should should be greater than the queue expiry with an" +
+                " additional buffer {}", reprocessorElapseTime, allowedReprocessTime);
+        }
+    }
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/queue/impl/MosipActiveMqImpl.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/queue/impl/MosipActiveMqImpl.java
@@ -88,6 +88,18 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
      */
     @Override
     public Boolean send(MosipQueue mosipQueue, byte[] message, String address) {
+        return send(mosipQueue, message, address, 0);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * io.mosip.registration.processor.core.spi.queue.MosipQueueManager#send(java.
+     * lang.Object, java.lang.Object, java.lang.String, long)
+     */
+    @Override
+    public Boolean send(MosipQueue mosipQueue, byte[] message, String address, int messageTTL) {
         regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
                 "", "MosipActiveMqImpl::send()::entry");
 
@@ -98,6 +110,8 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
             MessageProducer messageProducer = session.createProducer(destination);
             BytesMessage byteMessage = session.createBytesMessage();
             byteMessage.writeObject(message);
+            if(messageTTL > 0)
+                messageProducer.setTimeToLive(messageTTL * 1000);
             messageProducer.send(byteMessage);
             flag = true;
         } catch (JMSException e) {
@@ -117,6 +131,11 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
 
     @Override
     public Boolean send(MosipQueue mosipQueue, String message, String address) {
+        return send(mosipQueue, message, address, 0);
+    }
+
+    @Override
+    public Boolean send(MosipQueue mosipQueue, String message, String address, int messageTTL) {
         boolean flag = false;
         initialSetup(mosipQueue);
         try {
@@ -124,6 +143,8 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
             MessageProducer messageProducer = session.createProducer(destination);
             TextMessage textMessage = session.createTextMessage();
             textMessage.setText(message);
+            if(messageTTL > 0)
+                messageProducer.setTimeToLive(messageTTL * 1000);
             messageProducer.send(textMessage);
             flag = true;
         } catch (JMSException e) {

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/queue/MosipQueueManager.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/queue/MosipQueueManager.java
@@ -21,6 +21,17 @@ public interface MosipQueueManager<T, V>{
 	public Boolean send(T mosipQueue, V message, String address);
 
 	/**
+	 * This method sends a message on a given Address
+	 * 
+	 * @param mosipQueue The mosipQueue instance
+	 * @param message    The message
+	 * @param address    The address
+	 * @param messageTTL The timeToLive in seconds for message
+	 * @return True if message is sent, false otherwise
+	 */
+	public Boolean send(T mosipQueue, V message, String address, int messageTTL);
+
+	/**
 	 * This method sends a json string message on a given Address
 	 *
 	 * @param mosipQueue The mosipQueue instance
@@ -29,6 +40,17 @@ public interface MosipQueueManager<T, V>{
 	 * @return True if message is sent, false otherwise
 	 */
 	public Boolean send(T mosipQueue, String message, String address);
+
+	/**
+	 * This method sends a json string message on a given Address
+	 *
+	 * @param mosipQueue The mosipQueue instance
+	 * @param message    The message
+	 * @param address    The address
+	 * @param messageTTL The timeToLive in seconds for message
+	 * @return True if message is sent, false otherwise
+	 */
+	public Boolean send(T mosipQueue, String message, String address, int messageTTL);
 
 	/**
 	 * This method consumes a message from a given address

--- a/registration-processor/registration-processor-info-storage-service/src/main/java/io/mosip/registration/processor/abis/queue/dto/AbisQueueDetails.java
+++ b/registration-processor/registration-processor-info-storage-service/src/main/java/io/mosip/registration/processor/abis/queue/dto/AbisQueueDetails.java
@@ -21,5 +21,6 @@ public class AbisQueueDetails {
 	private String password;
 	private String typeOfQueue;
 	private MosipQueue mosipQueue;
+	private int inboundMessageTTL;
 
 }

--- a/registration-processor/registration-processor-info-storage-service/src/main/java/io/mosip/registration/processor/packet/storage/utils/Utilities.java
+++ b/registration-processor/registration-processor-info-storage-service/src/main/java/io/mosip/registration/processor/packet/storage/utils/Utilities.java
@@ -194,6 +194,9 @@ public class Utilities {
 	/** The Constant NAME. */
 	private static final String NAME = "name";
 
+	/** The Constant NAME. */
+	private static final String INBOUNDMESSAGETTL = "inboundMessageTTL";
+
 	/** The Constant FAIL_OVER. */
 	private static final String FAIL_OVER = "failover:(";
 
@@ -425,6 +428,7 @@ public class Utilities {
 				String inboundQueueName = validateAbisQueueJsonAndReturnValue(json, INBOUNDQUEUENAME);
 				String outboundQueueName = validateAbisQueueJsonAndReturnValue(json, OUTBOUNDQUEUENAME);
 				String queueName = validateAbisQueueJsonAndReturnValue(json, NAME);
+				int inboundMessageTTL = validateAbisQueueJsonAndReturnIntValue(json, INBOUNDMESSAGETTL);
 				MosipQueue mosipQueue = mosipConnectionFactory.createConnection(typeOfQueue, userName, password,
 						failOverBrokerUrl);
 				if (mosipQueue == null)
@@ -435,6 +439,7 @@ public class Utilities {
 				abisQueueDetails.setInboundQueueName(inboundQueueName);
 				abisQueueDetails.setOutboundQueueName(outboundQueueName);
 				abisQueueDetails.setName(queueName);
+				abisQueueDetails.setInboundMessageTTL(inboundMessageTTL);
 				abisQueueDetailsList.add(abisQueueDetails);
 
 			}
@@ -665,6 +670,28 @@ public class Utilities {
 		}
 
 		return value;
+	}
+
+	/**
+	 * Validate abis queue json and return long value.
+	 *
+	 * @param jsonObject
+	 *            the json object
+	 * @param key
+	 *            the key
+	 * @return the long value
+	 */
+	private int validateAbisQueueJsonAndReturnIntValue(JSONObject jsonObject, String key) {
+
+		Integer value = JsonUtil.getJSONValue(jsonObject, key);
+		if (value == null) {
+
+			throw new RegistrationProcessorUnCheckedException(
+					PlatformErrorMessages.ABIS_QUEUE_JSON_VALIDATION_FAILED.getCode(),
+					PlatformErrorMessages.ABIS_QUEUE_JSON_VALIDATION_FAILED.getMessage() + "::" + key);
+		}
+
+		return value.intValue();
 	}
 
 	/**


### PR DESCRIPTION
Changes:
1. ActiveMQ queue is added with ability to support optional expiry (TTL in seconds)
2. ABIS middleware stage changed to pass the expiry to the queue service