### PR TITLE
MOSIP-11244 : Camel routing based on tags feature

### DIFF
--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassificationProcessor.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassificationProcessor.java
@@ -205,6 +205,7 @@ public class PacketClassificationProcessor {
 			registrationStatusDto.setRegistrationStageName(stageName);
 
 			generateAndAddTags(registrationId, registrationStatusDto.getRegistrationType());
+			object.setTags(null);
 
 			registrationStatusDto.setLatestTransactionStatusCode(
 				RegistrationTransactionStatusCode.SUCCESS.toString());

--- a/registration-processor/registration-processor-common-camel-bridge/pom.xml
+++ b/registration-processor/registration-processor-common-camel-bridge/pom.xml
@@ -100,6 +100,11 @@
 			<artifactId>micrometer-registry-prometheus</artifactId>
 			<version>${io.micrometer.prometheus.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+  			<artifactId>camel-jsonpath</artifactId>
+			<version>${camel.vertx.version}</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageDTO.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageDTO.java
@@ -1,6 +1,7 @@
 package io.mosip.registration.processor.core.abstractverticle;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import io.mosip.registration.processor.core.constant.RegistrationType;
 
@@ -47,6 +48,9 @@ public class MessageDTO implements Serializable {
 
 	/** The retry count. */
 	private Integer retryCount;
+
+	/** The tags of the packets */
+	private Map<String, String> tags;
 
 	
 
@@ -146,6 +150,24 @@ public class MessageDTO implements Serializable {
 		return messageBusAddress;
 	}
 
+	/**
+	 * Gets the message tags
+	 *
+	 * @return the tags map
+	 */
+	public Map<String, String> getTags() {
+		return tags;
+	}
+
+	/**
+	 * Sets the tags map.
+	 *
+	 * @param tags the message tags
+	 */
+	public void setTags(Map<String, String> tags) {
+		this.tags = tags;
+	}
+
 	@Override
 	public String toString() {
 		String msgBusAddress=null;
@@ -157,4 +179,5 @@ public class MessageDTO implements Serializable {
 				+ ", internalError=" + internalError + ", messageBusAddress=" + msgBusAddress
 				+ ", retryCount=" + retryCount + '}';
 	}
+
 }

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleManager.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleManager.java
@@ -9,18 +9,32 @@ import java.util.concurrent.ExecutionException;
 
 import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.registration.processor.core.logger.RegProcessorLogger;
+import io.mosip.registration.processor.core.packet.dto.packetmanager.InfoRequestDto;
+import io.mosip.registration.processor.core.packet.dto.packetmanager.InfoResponseDto;
+
 import org.slf4j.MDC;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.UrlXmlConfig;
 
+import io.mosip.kernel.core.util.DateUtils;
+import io.mosip.kernel.core.util.JsonUtils;
+import io.mosip.kernel.core.util.exception.JsonProcessingException;
+import io.mosip.registration.processor.core.code.ApiName;
 import io.mosip.registration.processor.core.eventbus.MosipEventBusFactory;
 import io.mosip.registration.processor.core.exception.DeploymentFailureException;
 import io.mosip.registration.processor.core.exception.UnsupportedEventBusTypeException;
+import io.mosip.registration.processor.core.exception.ApisResourceAccessException;
+import io.mosip.registration.processor.core.exception.PacketManagerException;
 import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
+import io.mosip.registration.processor.core.http.RequestWrapper;
+import io.mosip.registration.processor.core.http.ResponseWrapper;
 import io.mosip.registration.processor.core.spi.eventbus.EventBusManager;
+import io.mosip.registration.processor.core.spi.restclient.RegistrationProcessorRestClientService;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Verticle;
@@ -46,6 +60,15 @@ public abstract class MosipVerticleManager extends AbstractVerticle
 
 	/** The logger. */
 	private Logger logger = RegProcessorLogger.getLogger(MosipVerticleManager.class);
+
+	private static final String ID = "mosip.commmons.packetmanager";
+    private static final String VERSION = "v1";
+
+    @Autowired
+    private RegistrationProcessorRestClientService<Object> restApi;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
 	@Value("${mosip.regproc.eventbus.type:vertx}")
 	private String eventBusType;
@@ -133,6 +156,8 @@ public abstract class MosipVerticleManager extends AbstractVerticle
 				JsonObject jsonObject = (JsonObject) msg.getBody();
 				MessageDTO messageDTO = jsonObject.mapTo(MessageDTO.class);
 				MessageDTO result = process(messageDTO);
+				if(result.getTags() == null)
+					addTagsToMessageDTO(result);
 				future.complete(result);
 			}, false, handler);
 			MDC.clear();
@@ -150,6 +175,8 @@ public abstract class MosipVerticleManager extends AbstractVerticle
 	 *            The message that needs to be sent
 	 */
 	public void send(MosipEventBus mosipEventBus, MessageBusAddress toAddress, MessageDTO message) {
+		if(message.getTags() == null)
+			addTagsToMessageDTO(message);
 		mosipEventBus.send(toAddress, message);
 	}
 
@@ -188,5 +215,39 @@ public abstract class MosipVerticleManager extends AbstractVerticle
 	protected void setMosipEventBusFactory(MosipEventBusFactory mosipEventBusFactory) {
 		this.mosipEventBusFactory = mosipEventBusFactory;
 	}
+
+	private void addTagsToMessageDTO(MessageDTO messageDTO) {
+		try {
+			messageDTO.setTags(getTagsFromPacket(messageDTO.getRid()));
+		} catch (ApisResourceAccessException | PacketManagerException | 
+				JsonProcessingException | IOException e) {
+			logger.error(PlatformErrorMessages.RPR_SYS_PACKET_TAGS_COPYING_FAILED.getCode() + 
+				" -- " + PlatformErrorMessages.RPR_SYS_PACKET_TAGS_COPYING_FAILED.getMessage() + 
+				e.getMessage() + ExceptionUtils.getStackTrace(e));
+			messageDTO.setInternalError(true);
+		}
+	}
+
+	private Map<String, String> getTagsFromPacket(String id) throws ApisResourceAccessException, 
+			PacketManagerException, JsonProcessingException, IOException {
+        InfoRequestDto infoRequestDto = new InfoRequestDto(id);
+
+        RequestWrapper<InfoRequestDto> request = new RequestWrapper<>();
+        request.setId(ID);
+        request.setVersion(VERSION);
+        request.setRequesttime(DateUtils.getUTCCurrentDateTime());
+        request.setRequest(infoRequestDto);
+        ResponseWrapper<InfoResponseDto> response = (ResponseWrapper) restApi.postApi(
+			ApiName.PACKETMANAGER_INFO, "", "", request, ResponseWrapper.class);
+
+        if (response.getErrors() != null && response.getErrors().size() > 0) {
+			throw new PacketManagerException(response.getErrors().get(0).getErrorCode(), 
+				response.getErrors().get(0).getMessage());
+        }
+
+        InfoResponseDto infoResponseDto = objectMapper.readValue(JsonUtils.javaObjectToJsonString(
+			response.getResponse()), InfoResponseDto.class);
+		return infoResponseDto.getInfo().getTags();
+    }
 
 }

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/VertxMosipEventBus.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/VertxMosipEventBus.java
@@ -66,7 +66,7 @@ public class VertxMosipEventBus implements MosipEventBus {
 			EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> eventHandler) {
 		vertx.eventBus().consumer(fromAddress.getAddress(), msg -> {
 			EventDTO eventDTO = new EventDTO();
-			eventDTO.setBody((JsonObject) msg.body());
+			eventDTO.setBody(new JsonObject((String)msg.body()));
 			eventHandler.handle(eventDTO, res -> {
 				if (!res.succeeded()) {
 					logger.error("Event handling failed ",res.cause());
@@ -87,7 +87,7 @@ public class VertxMosipEventBus implements MosipEventBus {
 			EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> eventHandler) {
 		vertx.eventBus().consumer(fromAddress.getAddress(), msg -> {
 			EventDTO eventDTO = new EventDTO();
-			eventDTO.setBody((JsonObject) msg.body());
+			eventDTO.setBody(new JsonObject((String) msg.body()));
 			eventHandler.handle(eventDTO, res -> {
 				if (!res.succeeded()) {
 					logger.error("Event handling failed ",res.cause());
@@ -95,7 +95,7 @@ public class VertxMosipEventBus implements MosipEventBus {
 					MessageDTO messageDTO = res.result();
 					MessageBusAddress messageBusToAddress = new MessageBusAddress(toAddress, messageDTO.getReg_type());
 					JsonObject jsonObject = JsonObject.mapFrom(messageDTO);
-					vertx.eventBus().send(messageBusToAddress.getAddress(), jsonObject);
+					vertx.eventBus().send(messageBusToAddress.getAddress(), jsonObject.toString());
 				}
 				MDCHelper.clearMDC();
 			});
@@ -113,7 +113,7 @@ public class VertxMosipEventBus implements MosipEventBus {
 		MessageBusAddress messageBusAddress = new MessageBusAddress(toAddress, message.getReg_type());
 		JsonObject jsonObject = JsonObject.mapFrom(message);
 		logger.debug("send called with toAddress {} for message {}",messageBusAddress.getAddress(), jsonObject.toString());
-		this.vertx.eventBus().send(messageBusAddress.getAddress(), jsonObject);
+		this.vertx.eventBus().send(messageBusAddress.getAddress(), jsonObject.toString());
 	}
 
 }

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/util/PlatformErrorMessages.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/util/PlatformErrorMessages.java
@@ -925,6 +925,10 @@ public enum PlatformErrorMessages {
 	OBJECT_STORE_NOT_ACCESSIBLE(PlatformConstants.RPR_SYSTEM_EXCEPTION + "018",
 			"Unable to Access Object Store"),
 
+	/** The packet tags copying failed. */
+	RPR_SYS_PACKET_TAGS_COPYING_FAILED(PlatformConstants.RPR_SYSTEM_EXCEPTION + "019",
+			"Packet tags copying to message event failed"),
+
 	// Cbeff Util Exceptions
 	/** The rpr utl biometric tag match. */
 	RPR_UTL_BIOMETRIC_TAG_MATCH(PlatformConstants.RPR_UTIL + "001", "Both Files have same biometrics"),

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/BiometricsDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/BiometricsDto.java
@@ -1,0 +1,12 @@
+package io.mosip.registration.processor.core.packet.dto.packetmanager;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BiometricsDto {
+
+    private String type;
+    private List<String> subtypes;
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/ContainerInfoDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/ContainerInfoDto.java
@@ -1,0 +1,22 @@
+package io.mosip.registration.processor.core.packet.dto.packetmanager;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Data
+@EqualsAndHashCode
+public class ContainerInfoDto {
+
+    private String source;
+    private String process;
+    private Date lastModified;
+    private Set<String> demographics;
+    private List<BiometricsDto> biometrics;
+    private Map<String, String> documents;
+
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/InfoRequestDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/InfoRequestDto.java
@@ -1,0 +1,10 @@
+package io.mosip.registration.processor.core.packet.dto.packetmanager;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class InfoRequestDto {
+    private String id;
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/InfoResponseDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/packet/dto/packetmanager/InfoResponseDto.java
@@ -1,0 +1,15 @@
+package io.mosip.registration.processor.core.packet.dto.packetmanager;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class InfoResponseDto {
+    private String applicationId;
+    private String packetId;
+    private String requestToken;
+    private List<ContainerInfoDto> info;
+    private Map<String, String> tags;
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/tracing/EventTracingHandler.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/tracing/EventTracingHandler.java
@@ -110,7 +110,7 @@ public class EventTracingHandler {
     public void readHeaderOnConsume(EventBus eventBus) {
         eventBus.addInboundInterceptor(deliveryContext -> {
             Span span = nextSpan(deliveryContext.message());
-            JsonObject body = (JsonObject) deliveryContext.message().body();
+            JsonObject body = new JsonObject((String) deliveryContext.message().body());
             initializeContextWithTracing(span, body == null ? "-" : (body.getString("rid", "-")));
             MDCHelper.addHeadersToMDC();
             deliveryContext.next();
@@ -123,7 +123,7 @@ public class EventTracingHandler {
             Span span = (tracer instanceof TracingHandler) ? ((TracingHandler)tracer).span : (Span)tracer;
             if(span == null) {
                 span = nextSpan(deliveryContext.message());
-                JsonObject body = (JsonObject) deliveryContext.message().body();
+                JsonObject body = new JsonObject((String) deliveryContext.message().body());
                 initializeContextWithTracing(span, body == null ? "-" : (body.getString("rid", "-")));
                 MDCHelper.addHeadersToMDC();
             }

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/abstractverticle/MosipVerticleManagerConsumeTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/abstractverticle/MosipVerticleManagerConsumeTest.java
@@ -77,7 +77,7 @@ public class MosipVerticleManagerConsumeTest {
 		});
 
 		JsonObject jsonObject = JsonObject.mapFrom(this.messageDTO);
-		vertx.eventBus().send(MessageBusAddress.DEMO_DEDUPE_BUS_IN.getAddress(), jsonObject);
+		vertx.eventBus().send(MessageBusAddress.DEMO_DEDUPE_BUS_IN.getAddress(), jsonObject.toString());
 		async.awaitSuccess();
 	}
 
@@ -86,7 +86,7 @@ public class MosipVerticleManagerConsumeTest {
 		final Async async = testContext.async();
 		JsonObject jsonObject = JsonObject.mapFrom(this.messageDTO);
 
-		vertx.eventBus().send(MessageBusAddress.PACKET_VALIDATOR_BUS_IN.getAddress(), jsonObject);
+		vertx.eventBus().send(MessageBusAddress.PACKET_VALIDATOR_BUS_IN.getAddress(), jsonObject.toString());
 		async.complete();
 		async.awaitSuccess();
 
@@ -105,13 +105,13 @@ public class MosipVerticleManagerConsumeTest {
 			testContext.assertTrue(msg.body().toString().contains(this.messageDTO.getMessageBusAddress().getAddress()));
 			testContext.assertTrue(msg.body().toString().contains("NEW"));
 
-			vertx.eventBus().send(MessageBusAddress.PACKET_VALIDATOR_BUS_OUT.getAddress(), jsonObject);
+			vertx.eventBus().send(MessageBusAddress.PACKET_VALIDATOR_BUS_OUT.getAddress(), jsonObject.toString());
 
 			if (!async.isCompleted())
 				async.complete();
 		});
 
-		vertx.eventBus().send(MessageBusAddress.RETRY_BUS.getAddress(), jsonObject);
+		vertx.eventBus().send(MessageBusAddress.RETRY_BUS.getAddress(), jsonObject.toString());
 		async.awaitSuccess();
 	}
 }


### PR DESCRIPTION
Changes:
1. When the tags in event is null, mosip verticle manager will fetch the tags from packet manager and will add it to the event before sending in the event bus
2. Vertx event bus message transmission format changed from JsonObject to String to make it compatible with JsonPath library in camel
3. JsonPath dependency added to camel bridge