### PR TITLE
MOSIP-11244 : Time module registered with default object mapper bean

### DIFF
--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/config/CoreConfigBean.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/config/CoreConfigBean.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import brave.Tracer;
 import brave.Tracing;
@@ -181,6 +182,6 @@ public class CoreConfigBean {
 
 	@Bean
 	public ObjectMapper getObjectMapper() {
-		return new ObjectMapper();
+		return new ObjectMapper().registerModule(new JavaTimeModule());
 	}
 }


### PR DESCRIPTION
This change is to avoid object mapper issue in registration status service in dmz