### PR TITLE
MOSIP-12370 : Message expiry feature added to the event bus

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
@@ -112,6 +112,10 @@ public class AbisHandlerStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.abis.handler.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	@Value("${registration.processor.policy.id}")
 	private String policyId;
 
@@ -164,7 +168,7 @@ public class AbisHandlerStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.ABIS_HANDLER_BUS_IN,
-				MessageBusAddress.ABIS_HANDLER_BUS_OUT);
+				MessageBusAddress.ABIS_HANDLER_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-abis-handler-stage/src/test/java/io/mosip/registration/processor/abis/handler/stage/test/AbisHandlerStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-handler-stage/src/test/java/io/mosip/registration/processor/abis/handler/stage/test/AbisHandlerStageTest.java
@@ -151,7 +151,7 @@ public class AbisHandlerStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -160,6 +160,7 @@ public class AbisHandlerStageTest {
 		ReflectionTestUtils.setField(abisHandlerStage, "maxResults", "30");
 		ReflectionTestUtils.setField(abisHandlerStage, "targetFPIR", "30");
 		ReflectionTestUtils.setField(abisHandlerStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(abisHandlerStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(abisHandlerStage, "clusterManagerUrl", "/dummyPath");
 		Mockito.when(env.getProperty("mosip.registration.processor.datetime.pattern"))
 				.thenReturn("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -123,6 +123,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.abis.middleware.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** Message Format. */
 	@Value("${activemq.message.format}")
 	private String messageFormat;
@@ -150,7 +154,7 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 		try {
 			
 			mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-			this.consume(mosipEventBus, MessageBusAddress.ABIS_MIDDLEWARE_BUS_IN);
+			this.consume(mosipEventBus, MessageBusAddress.ABIS_MIDDLEWARE_BUS_IN, messageExpiryTimeLimit);
 			abisQueueDetails = utility.getAbisQueueDetails();
 			for (AbisQueueDetails abisQueue : abisQueueDetails) {
 				String abisInBoundaddress = abisQueue.getInboundQueueName();

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
@@ -134,11 +134,12 @@ public class AbisMiddleWareStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 
 		@Override
-		public void consume(MosipEventBus mosipEventBus, MessageBusAddress fromAddress) {
+		public void consume(MosipEventBus mosipEventBus, MessageBusAddress fromAddress, 
+			long messageExpiryTimeLimit) {
 
 		}
 
@@ -149,6 +150,7 @@ public class AbisMiddleWareStageTest {
 		MockitoAnnotations.openMocks(this);
 		ReflectionTestUtils.setField(stage, "messageFormat", "byte");
 		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		InternalRegistrationStatusDto internalRegStatusDto = new InternalRegistrationStatusDto();
 		internalRegStatusDto.setRegistrationId("");

--- a/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
@@ -37,6 +37,10 @@ public class BioDedupeStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.bio.dedupe.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** Mosip router for APIs */
 	@Autowired
 	MosipRouter router;
@@ -48,7 +52,8 @@ public class BioDedupeStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIO_DEDUPE_BUS_IN, MessageBusAddress.BIO_DEDUPE_BUS_OUT);
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIO_DEDUPE_BUS_IN, 
+			MessageBusAddress.BIO_DEDUPE_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/test/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStageTest.java
+++ b/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/test/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStageTest.java
@@ -82,7 +82,7 @@ public class BioDedupeStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -92,6 +92,7 @@ public class BioDedupeStageTest {
 	@Test
 	public void testDeployVerticle() {
 		ReflectionTestUtils.setField(bioDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(bioDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(bioDedupeStage, "clusterManagerUrl", "/dummyPath");
 		bioDedupeStage.deployVerticle();
 	}
@@ -108,6 +109,7 @@ public class BioDedupeStageTest {
 	@Test
 	public void testStart() {
 		ReflectionTestUtils.setField(bioDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(bioDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(bioDedupeStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(bioDedupeStage, "port", "1080");
 		

--- a/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
+++ b/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
@@ -101,6 +101,10 @@ public class BiometricAuthenticationStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.biometric.authentication.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** The mosip event bus. */
 	MosipEventBus mosipEventBus = null;
 
@@ -114,7 +118,7 @@ public class BiometricAuthenticationStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_IN,
-				MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_OUT);
+				MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/test/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/test/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStageTest.java
@@ -160,7 +160,7 @@ public class BiometricAuthenticationStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -213,6 +213,7 @@ public class BiometricAuthenticationStageTest {
 	@Before
 	public void setUp() throws Exception {
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(biometricAuthenticationStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "ageLimit", "5");
 

--- a/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
@@ -32,6 +32,10 @@ public class DemoDedupeStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.demo.dedupe.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	private MosipEventBus mosipEventBus = null;
 	@Autowired
 	DemodedupeProcessor demodedupeProcessor;
@@ -46,7 +50,8 @@ public class DemoDedupeStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.DEMO_DEDUPE_BUS_IN, MessageBusAddress.DEMO_DEDUPE_BUS_OUT);
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.DEMO_DEDUPE_BUS_IN, 
+			MessageBusAddress.DEMO_DEDUPE_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/test/java/io/mosip/registrationprocessor/stages/demodedupe/DemoDedupeStageTest.java
+++ b/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/test/java/io/mosip/registrationprocessor/stages/demodedupe/DemoDedupeStageTest.java
@@ -74,7 +74,7 @@ public class DemoDedupeStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -84,6 +84,7 @@ public class DemoDedupeStageTest {
 	@Test
 	public void testDeployVerticle() {
 		ReflectionTestUtils.setField(demoDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(demoDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(demoDedupeStage, "clusterManagerUrl", "/dummyPath");
 		demoDedupeStage.deployVerticle();
 	}
@@ -100,6 +101,7 @@ public class DemoDedupeStageTest {
 	@Test
 	public void testStart() {
 		ReflectionTestUtils.setField(demoDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(demoDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(demoDedupeStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(demoDedupeStage, "port", "1080");
 		

--- a/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/stage/ManualVerificationStage.java
+++ b/registration-processor/core-processor/registration-processor-manual-verification-stage/src/main/java/io/mosip/registration/processor/manual/verification/stage/ManualVerificationStage.java
@@ -143,6 +143,10 @@ public class ManualVerificationStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.manual.verification.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	@Value("${server.servlet.path}")
 	private String contextPath;
 
@@ -153,7 +157,8 @@ public class ManualVerificationStage extends MosipVerticleAPIManager {
 	 */
 	public void deployStage() {
 		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.MANUAL_VERIFICATION_BUS_IN, MessageBusAddress.MANUAL_VERIFICATION_BUS_OUT);
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.MANUAL_VERIFICATION_BUS_IN, 
+			MessageBusAddress.MANUAL_VERIFICATION_BUS_OUT, messageExpiryTimeLimit);
 		queue = getQueueConnection();
 		if (queue != null) {
 

--- a/registration-processor/core-processor/registration-processor-manual-verification-stage/src/test/java/io/mosip/registration/processor/manual/verification/stage/ManualVerificationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-manual-verification-stage/src/test/java/io/mosip/registration/processor/manual/verification/stage/ManualVerificationStageTest.java
@@ -119,6 +119,7 @@ public class ManualVerificationStageTest{
 		ReflectionTestUtils.setField(manualverificationstage, "port", "8080");
 		ReflectionTestUtils.setField(manualverificationstage, "contextPath", "/registrationprocessor/v1/manualverification");
 		ReflectionTestUtils.setField(manualverificationstage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(manualverificationstage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(manualverificationstage, "clusterManagerUrl", "/dummyPath");
 		//Mockito.when(env.getProperty(SwaggerConstant.SERVER_SERVLET_PATH)).thenReturn("/registrationprocessor/v1/manualverification");
 		Mockito.when(mosipConnectionFactory.createConnection(any(),any(),any(),any())).thenReturn(mosipQueue);

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
@@ -135,6 +135,10 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.uin.generator.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** The core audit request builder. */
 	@Autowired
 	private AuditLogRequestBuilder auditLogRequestBuilder;
@@ -995,7 +999,7 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.UIN_GENERATION_BUS_IN,
-				MessageBusAddress.UIN_GENERATION_BUS_OUT);
+				MessageBusAddress.UIN_GENERATION_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
@@ -147,7 +147,7 @@ public class UinGeneratorStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -230,6 +230,7 @@ public class UinGeneratorStageTest {
 	@Before
 	public void setup() throws Exception {
 		ReflectionTestUtils.setField(uinGeneratorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(uinGeneratorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(uinGeneratorStage, "clusterManagerUrl", "/dummyPath");
 
 		ClassLoader classLoader1 = getClass().getClassLoader();

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
@@ -154,6 +154,10 @@ public class MessageSenderStage extends MosipVerticleAPIManager {
 	/** worker pool size. */
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
+
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.message.sender.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
 	
 	@Autowired
 	private SyncRegistrationService<SyncResponseDto, SyncRegistrationDto> syncRegistrationservice;
@@ -162,7 +166,7 @@ public class MessageSenderStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		MosipEventBus mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consume(mosipEventBus, MessageBusAddress.MESSAGE_SENDER_BUS);
+		this.consume(mosipEventBus, MessageBusAddress.MESSAGE_SENDER_BUS, messageExpiryTimeLimit);
 	}
 
 	/*

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/test/java/io/mosip/registration/processor/message/sender/stage/test/MessageSenderStageTest.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/test/java/io/mosip/registration/processor/message/sender/stage/test/MessageSenderStageTest.java
@@ -160,13 +160,14 @@ public class MessageSenderStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
 	@Before
 	public void setup() throws Exception {
 		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(stage, "notificationTypes", "SMS|EMAIL");
 		ReflectionTestUtils.setField(stage, "uinGeneratedSubject", "UIN generated");

--- a/registration-processor/post-processor/registration-processor-printing-stage/src/main/java/io/mosip/registration/processor/print/stage/PrintingStage.java
+++ b/registration-processor/post-processor/registration-processor-printing-stage/src/main/java/io/mosip/registration/processor/print/stage/PrintingStage.java
@@ -104,6 +104,10 @@ public class PrintingStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.printing.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 
 	@Value("${mosip.registration.processor.encrypt:false}")
 	private boolean encrypt;
@@ -138,7 +142,7 @@ public class PrintingStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consume(mosipEventBus, MessageBusAddress.PRINTING_BUS);
+		this.consume(mosipEventBus, MessageBusAddress.PRINTING_BUS, messageExpiryTimeLimit);
 
 
 	}

--- a/registration-processor/post-processor/registration-processor-printing-stage/src/test/java/io/mosip/registrationprocessor/print/stage/test/PrintingStageTest.java
+++ b/registration-processor/post-processor/registration-processor-printing-stage/src/test/java/io/mosip/registrationprocessor/print/stage/test/PrintingStageTest.java
@@ -137,7 +137,8 @@ public class PrintingStageTest {
 		}
 
 		@Override
-		public void consume(MosipEventBus mosipEventBus, MessageBusAddress fromAddress) {
+		public void consume(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
+			long messageExpiryTimeLimit) {
 		}
 
 
@@ -167,6 +168,7 @@ public class PrintingStageTest {
 				.thenReturn("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
 		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		System.setProperty("server.port", "8099");
 

--- a/registration-processor/pre-processor/registration-processor-external-stage/src/main/java/io/mosip/registrationprocessor/externalstage/stage/ExternalStage.java
+++ b/registration-processor/pre-processor/registration-processor-external-stage/src/main/java/io/mosip/registrationprocessor/externalstage/stage/ExternalStage.java
@@ -66,6 +66,10 @@ public class ExternalStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.external.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	@Autowired
 	private AuditLogRequestBuilder auditLogRequestBuilder;
 
@@ -97,7 +101,7 @@ public class ExternalStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.EXTERNAL_STAGE_BUS_IN,
-				MessageBusAddress.EXTERNAL_STAGE_BUS_OUT);
+				MessageBusAddress.EXTERNAL_STAGE_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	/*

--- a/registration-processor/pre-processor/registration-processor-external-stage/src/test/java/io/mosip/registrationprocessor/externalstage/stage/ExternalStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-external-stage/src/test/java/io/mosip/registrationprocessor/externalstage/stage/ExternalStageTest.java
@@ -44,7 +44,7 @@ public class ExternalStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 		@Override
 		public Router postUrl(Vertx vertx, MessageBusAddress consumeAddress, MessageBusAddress sendAddress) {
@@ -84,6 +84,7 @@ public class ExternalStageTest {
 	public void setUp() throws Exception {
 		ReflectionTestUtils.setField(externalStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(externalStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(externalStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(externalStage, "port","8989");
 		dto.setInternalError(false);
 		dto.setIsValid(true);

--- a/registration-processor/pre-processor/registration-processor-osi-validator-stage/src/main/java/io/mosip/registration/processor/stages/osivalidator/OSIValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-osi-validator-stage/src/main/java/io/mosip/registration/processor/stages/osivalidator/OSIValidatorStage.java
@@ -92,6 +92,10 @@ public class OSIValidatorStage extends MosipVerticleAPIManager {
 	/** worker pool size. */
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
+
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.osi.validator.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
 	
 	@Value("${mosip.registartion.processor.validateUMC}")
 	private boolean validateUMC;
@@ -105,7 +109,8 @@ public class OSIValidatorStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.OSI_BUS_IN, MessageBusAddress.OSI_BUS_OUT);
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.OSI_BUS_IN, MessageBusAddress.OSI_BUS_OUT,
+			messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-osi-validator-stage/src/test/java/io/mosip/registration/processor/stages/osivalidator/OSIValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-osi-validator-stage/src/test/java/io/mosip/registration/processor/stages/osivalidator/OSIValidatorStageTest.java
@@ -71,7 +71,7 @@ public class OSIValidatorStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -125,6 +125,7 @@ public class OSIValidatorStageTest {
 
 		ReflectionTestUtils.setField(osiValidatorStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(osiValidatorStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(osiValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(osiValidatorStage, "validateUMC", true);
 
 		@SuppressWarnings("unchecked")

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
@@ -44,6 +44,10 @@ public class PacketClassifierStage extends MosipVerticleAPIManager {
 	@Value("${mosip.regproc.packet.classifier.eventbus.port}")
 	private String eventBusPort;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.packet.classifier.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** The mosip event bus. */
 	MosipEventBus mosipEventBus = null;
 
@@ -53,7 +57,7 @@ public class PacketClassifierStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_CLASSIFIER_BUS_IN,
-				MessageBusAddress.PACKET_CLASSIFIER_BUS_OUT);
+				MessageBusAddress.PACKET_CLASSIFIER_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/test/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/test/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStageTest.java
@@ -66,7 +66,7 @@ public class PacketClassifierStageTest {
 		
 		@Override
 		public void consumeAndSend(MosipEventBus eventbus, MessageBusAddress addressbus1,
-				MessageBusAddress addressbus2) {
+				MessageBusAddress addressbus2, long messageExpiryTimeLimit) {
 		}
 		
 		@Override
@@ -93,6 +93,7 @@ public class PacketClassifierStageTest {
 		
 		ReflectionTestUtils.setField(packetClassifierStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(packetClassifierStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(packetClassifierStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetClassifierStage.deployVerticle();
 	}
 

--- a/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
@@ -36,6 +36,10 @@ public class PacketUploaderStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.packet.uploader.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/**
 	 * The mosip event bus.
 	 */
@@ -59,7 +63,7 @@ public class PacketUploaderStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl ,workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_UPLOADER_IN,
-				MessageBusAddress.PACKET_UPLOADER_OUT);
+				MessageBusAddress.PACKET_UPLOADER_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/test/java/io/mosip/registration/processor/packet/uploader/stage/test/PacketUploaderStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/test/java/io/mosip/registration/processor/packet/uploader/stage/test/PacketUploaderStageTest.java
@@ -105,7 +105,7 @@ public class PacketUploaderStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus eventbus, MessageBusAddress addressbus1,
-								   MessageBusAddress addressbus2) {
+								   MessageBusAddress addressbus2, long messageExpiryTimeLimit) {
 		}
 
 		@Override
@@ -134,6 +134,7 @@ public class PacketUploaderStageTest {
 
 		ReflectionTestUtils.setField(packetValidatorStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(packetValidatorStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(packetValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetValidatorStage.deployVerticle();
 	}
 

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
@@ -40,6 +40,11 @@ public class PacketValidatorStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.packet.validator.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
+	
 	/** The mosip event bus. */
 	MosipEventBus mosipEventBus = null;
 
@@ -53,7 +58,7 @@ public class PacketValidatorStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_VALIDATOR_BUS_IN,
-				MessageBusAddress.PACKET_VALIDATOR_BUS_OUT);
+				MessageBusAddress.PACKET_VALIDATOR_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStageTest.java
@@ -67,7 +67,7 @@ public class PacketValidatorStageTest {
 		
 		@Override
 		public void consumeAndSend(MosipEventBus eventbus, MessageBusAddress addressbus1,
-				MessageBusAddress addressbus2) {
+				MessageBusAddress addressbus2, long messageExpiryTimeLimit) {
 		}
 		
 		@Override
@@ -96,6 +96,7 @@ public class PacketValidatorStageTest {
 		
 		ReflectionTestUtils.setField(packetValidatorStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(packetValidatorStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(packetValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetValidatorStage.deployVerticle();
 	}
 

--- a/registration-processor/pre-processor/registration-processor-quality-checker-stage/src/main/java/io/mosip/registration/processor/quality/checker/stage/QualityCheckerStage.java
+++ b/registration-processor/pre-processor/registration-processor-quality-checker-stage/src/main/java/io/mosip/registration/processor/quality/checker/stage/QualityCheckerStage.java
@@ -121,6 +121,10 @@ public class QualityCheckerStage extends MosipVerticleAPIManager {
 	@Value("${worker.pool.size}")
 	private Integer workerPoolSize;
 
+	/** After this time intervel, message should be considered as expired (In seconds). */
+	@Value("${mosip.regproc.quality.checker.message.expiry-time-limit}")
+	private Long messageExpiryTimeLimit;
+
 	/** The core audit request builder. */
 	@Autowired
 	private AuditLogRequestBuilder auditLogRequestBuilder;
@@ -176,7 +180,7 @@ public class QualityCheckerStage extends MosipVerticleAPIManager {
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.QUALITY_CHECKER_BUS_IN,
-				MessageBusAddress.QUALITY_CHECKER_BUS_OUT);
+				MessageBusAddress.QUALITY_CHECKER_BUS_OUT, messageExpiryTimeLimit);
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-quality-checker-stage/src/test/java/io/mosip/registration/processor/quality/checker/stage/test/QualityCheckerStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-quality-checker-stage/src/test/java/io/mosip/registration/processor/quality/checker/stage/test/QualityCheckerStageTest.java
@@ -122,7 +122,7 @@ public class QualityCheckerStageTest {
 
 		@Override
 		public void consumeAndSend(MosipEventBus mosipEventBus, MessageBusAddress fromAddress,
-				MessageBusAddress toAddress) {
+				MessageBusAddress toAddress, long messageExpiryTimeLimit) {
 		}
 	};
 
@@ -130,6 +130,7 @@ public class QualityCheckerStageTest {
 	public void setUp() throws Exception {
 		ReflectionTestUtils.setField(qualityCheckerStage, "workerPoolSize", 10);
 		ReflectionTestUtils.setField(qualityCheckerStage, "clusterManagerUrl", "/dummyPath");
+		ReflectionTestUtils.setField(qualityCheckerStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(qualityCheckerStage, "irisThreshold", 70);
 		ReflectionTestUtils.setField(qualityCheckerStage, "leftFingerThreshold", 80);
 		ReflectionTestUtils.setField(qualityCheckerStage, "rightFingerThreshold", 80);

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -72,6 +72,10 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
     @Value("${server.servlet.path}")
     private String contextPath;
 
+    /** After this time intervel, message should be considered as expired (In seconds). */
+    @Value("${mosip.regproc.securezone.notification.message.expiry-time-limit}")
+    private Long messageExpiryTimeLimit;
+
     /** The Constant USER. */
     private static final String USER = "MOSIP_SYSTEM";
 
@@ -98,7 +102,7 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
     public void deployVerticle() {
         this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
         this.consumeAndSend(mosipEventBus, MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
-                MessageBusAddress.SECUREZONE_NOTIFICATION_OUT);
+                MessageBusAddress.SECUREZONE_NOTIFICATION_OUT, messageExpiryTimeLimit);
     }
 
     @Override

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/test/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/test/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStageTest.java
@@ -380,6 +380,7 @@ public class SecurezoneNotificationStageTest {
         ctx = setContext();
         ReflectionTestUtils.setField(notificationStage, "workerPoolSize", 10);
         ReflectionTestUtils.setField(notificationStage, "clusterManagerUrl", "/dummyPath");
+        ReflectionTestUtils.setField(notificationStage, "messageExpiryTimeLimit", Long.valueOf(0));
         ReflectionTestUtils.setField(notificationStage, "port", "7999");
         Mockito.when(router.post(Mockito.any())).thenReturn(null);
         Mockito.doNothing().when(router).setRoute(Mockito.any());

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageDTO.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageDTO.java
@@ -52,7 +52,8 @@ public class MessageDTO implements Serializable {
 	/** The tags of the packets */
 	private Map<String, String> tags;
 
-	
+	/** The timestamp when last stage hop was completed */
+	private String lastHopTimestamp;
 
 	/**
 	 * Gets the rid.
@@ -166,6 +167,24 @@ public class MessageDTO implements Serializable {
 	 */
 	public void setTags(Map<String, String> tags) {
 		this.tags = tags;
+	}
+
+	/**
+	 * Gets the last hop timestamp
+	 *
+	 * @return last hop timestamp in ISO format
+	 */
+	public String getLastHopTimestamp() {
+		return lastHopTimestamp;
+	}
+
+	/**
+	 * Sets the last hop timestamp.
+	 *
+	 * @param lastHopTimestamp the timestamp in ISO format
+	 */
+	public void setLastHopTimestamp(String lastHopTimestamp) {
+		this.lastHopTimestamp = lastHopTimestamp;
 	}
 
 	@Override

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/VertxMosipEventBus.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/VertxMosipEventBus.java
@@ -4,6 +4,7 @@ import io.mosip.registration.processor.core.abstractverticle.EventDTO;
 import io.mosip.registration.processor.core.abstractverticle.MessageBusAddress;
 import io.mosip.registration.processor.core.abstractverticle.MessageDTO;
 import io.mosip.registration.processor.core.abstractverticle.MosipEventBus;
+import io.mosip.registration.processor.core.exception.MessageExpiredException;
 import io.mosip.registration.processor.core.spi.eventbus.EventHandler;
 import io.mosip.registration.processor.core.tracing.EventTracingHandler;
 import io.mosip.registration.processor.core.tracing.MDCHelper;
@@ -68,8 +69,10 @@ public class VertxMosipEventBus implements MosipEventBus {
 			EventDTO eventDTO = new EventDTO();
 			eventDTO.setBody(new JsonObject((String)msg.body()));
 			eventHandler.handle(eventDTO, res -> {
-				if (!res.succeeded()) {
-					logger.error("Event handling failed ",res.cause());
+				if (!res.succeeded() && res.cause() instanceof MessageExpiredException) {
+					logger.warn("Event handling failed {}", res.cause().getMessage());
+				} else if (!res.succeeded()) {
+					logger.error("Event handling failed {}",res.cause());
 				}
 				MDCHelper.clearMDC();
 			});
@@ -89,8 +92,10 @@ public class VertxMosipEventBus implements MosipEventBus {
 			EventDTO eventDTO = new EventDTO();
 			eventDTO.setBody(new JsonObject((String) msg.body()));
 			eventHandler.handle(eventDTO, res -> {
-				if (!res.succeeded()) {
-					logger.error("Event handling failed ",res.cause());
+				if (!res.succeeded() && res.cause() instanceof MessageExpiredException) {
+					logger.warn("Event handling failed {}", res.cause().getMessage());
+				} else if (!res.succeeded()) {
+					logger.error("Event handling failed {}", res.cause());
 				} else {
 					MessageDTO messageDTO = res.result();
 					MessageBusAddress messageBusToAddress = new MessageBusAddress(toAddress, messageDTO.getReg_type());

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/MessageExpiredException.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/MessageExpiredException.java
@@ -1,0 +1,44 @@
+package io.mosip.registration.processor.core.exception;
+
+import io.mosip.kernel.core.exception.BaseUncheckedException;
+import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
+
+/**
+ * The Class MessageExpiredException.
+ */
+public class MessageExpiredException extends BaseUncheckedException {
+
+	/** The Constant serialVersionUID. */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Instantiates a new message expired exception.
+	 */
+	public MessageExpiredException() {
+		super();
+	}
+
+	/**
+	 * Instantiates a new message expired exception.
+	 *
+	 * @param message
+	 *            the message
+	 */
+	public MessageExpiredException(String message) {
+		super(PlatformErrorMessages.RPR_SYS_MESSAGE_EXPIRED.getCode(), 
+			PlatformErrorMessages.RPR_SYS_MESSAGE_EXPIRED.getMessage() + " " + message);
+	}
+
+	/**
+	 * Instantiates a new message expired exception.
+	 *
+	 * @param message
+	 *            the message
+	 * @param cause
+	 *            the cause
+	 */
+	public MessageExpiredException(String message, Throwable cause) {
+		super(PlatformErrorMessages.RPR_SYS_MESSAGE_EXPIRED.getCode() + EMPTY_SPACE, message, cause);
+	}
+
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/util/PlatformErrorMessages.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/exception/util/PlatformErrorMessages.java
@@ -929,6 +929,10 @@ public enum PlatformErrorMessages {
 	RPR_SYS_PACKET_TAGS_COPYING_FAILED(PlatformConstants.RPR_SYSTEM_EXCEPTION + "019",
 			"Packet tags copying to message event failed"),
 
+	/** The message expired. */
+	RPR_SYS_MESSAGE_EXPIRED(PlatformConstants.RPR_SYSTEM_EXCEPTION + "020",
+			"Message expired as per the last hop timestamp"),
+
 	// Cbeff Util Exceptions
 	/** The rpr utl biometric tag match. */
 	RPR_UTL_BIOMETRIC_TAG_MATCH(PlatformConstants.RPR_UTIL + "001", "Both Files have same biometrics"),

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/eventbus/EventBusManager.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/eventbus/EventBusManager.java
@@ -35,8 +35,10 @@ public interface EventBusManager<T, U, V> {
 	 * @param eventBus            The Eventbus instance for communication
 	 * @param fromAddress            The address from which message is to be consumed
 	 * @param toAddress            The address to which message needs to be sent
+	 * @param messageExpiryTimeLimit	The time limit in seconds, after which message should 
+	 * 									considered as expired
 	 */
-	public void consumeAndSend(T eventBus, U fromAddress, U toAddress);
+	public void consumeAndSend(T eventBus, U fromAddress, U toAddress, long messageExpiryTimeLimit);
 
 	/**
 	 * This method processes on the supplied object and returns the modified object.


### PR DESCRIPTION
Changes:
1. core library change to add timestamp and validate expiry
2. All stages and unit test cases changed to include the passing of message expiry time limit in consume and consumeAndSend method implementations