### PR TITLE
MOSIP-13492 : Different tags loaded while reprocessing issue resolved.

### DIFF
--- a/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/reprocessor/stage/ReprocessorStage.java
+++ b/registration-processor/core-processor/registration-processor-reprocessor-stage/src/main/java/io/mosip/registration/processor/reprocessor/stage/ReprocessorStage.java
@@ -234,6 +234,7 @@ public class ReprocessorStage extends MosipVerticleAPIManager {
 			if (!CollectionUtils.isEmpty(reprocessorDtoList)) {
 				reprocessorDtoList.forEach(dto -> {
 					this.registrationId = dto.getRegistrationId();
+					object = new MessageDTO();
 					if (reprocessCount.equals(dto.getReProcessRetryCount())) {
 						dto.setLatestTransactionStatusCode(
 								RegistrationTransactionStatusCode.REPROCESS_FAILED.toString());


### PR DESCRIPTION
Changes:
While reprocessing same message DTO object was reused causing tags of 1st object to be resued for all rids in that batch, fixed by creating a new message DTO object everytime