### PR TITLE
MOSIP-13087 : Changes in regproc to give out conditional processed status to regclient when packet is safe to delete

### DIFF
--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/test/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStageTest.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/test/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStageTest.java
@@ -102,8 +102,14 @@ public class PacketReceiverStageTest {
 			
 		}
 		
+		@Override
 		public Integer getPort() {
 			return 8080;
+		}
+
+		@Override
+		public String getServletPath() {
+			return null;
 		}
 	};
 

--- a/registration-processor/init/registration-processor-registration-status-service/README.md
+++ b/registration-processor/init/registration-processor-registration-status-service/README.md
@@ -20,5 +20,7 @@ server.servlet.path=/registrationprocessor/v1/registrationstatus
 registration.processor.max.retry=3
 mosip.registration.processor.registration.status.id=mosip.registration.status
 mosip.registration.processor.registration.sync.id=mosip.registration.sync
-
+# The comma separate list of external statuses that should be considered as processed 
+# for search API response consumed by regclient
+mosip.registration.processor.registration.status.external-statuses-to-consider-processed=UIN_GENERATED,REREGISTER,REJECTED,REPROCESS_FAILED	
 ```

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
@@ -76,6 +76,13 @@ public class RegistrationStatusController {
 	@Value("${registration.processor.signature.isEnabled}")
 	private Boolean isEnabled;
 
+	/** 
+	 * The comma separate list of external statuses that should be considered as processed 
+	 * for search API response consumed by regclient
+	 */
+	@Value("#{'${mosip.registration.processor.registration.status.external-statuses-to-consider-processed:UIN_GENERATED,REREGISTER,REJECTED,REPROCESS_FAILED}'.split(',')}")
+	private List<String> externalStatusesConsideredProcessed;
+
 	@Autowired
 	private DigitalSignatureUtility digitalSignatureUtility;
 
@@ -100,6 +107,7 @@ public class RegistrationStatusController {
 					env.getProperty(REG_STATUS_SERVICE_ID));
 			List<RegistrationStatusDto> registrations = registrationStatusService
 					.getByIds(registrationStatusRequestDTO.getRequest());
+			
 			List<RegistrationStatusSubRequestDto> requestIdsNotAvailable = registrationStatusRequestDTO.getRequest()
 					.stream()
 					.filter(request -> registrations.stream().noneMatch(
@@ -109,6 +117,8 @@ public class RegistrationStatusController {
 			if (registrationsList != null && !registrationsList.isEmpty()) {
 				registrations.addAll(syncRegistrationService.getByIds(requestIdsNotAvailable));
 			}
+
+			updatedConditionalStatusToProcessed(registrations);
 
 			if (isEnabled) {
 				RegStatusResponseDTO response = buildRegistrationStatusResponse(registrations,
@@ -155,6 +165,13 @@ public class RegistrationStatusController {
 		}
 		response.setErrors(errors);
 		return response;
+	}
+
+	private void updatedConditionalStatusToProcessed(List<RegistrationStatusDto> registrations) {
+		for(RegistrationStatusDto registrationStatusDto : registrations) {
+			if(externalStatusesConsideredProcessed.contains(registrationStatusDto.getStatusCode()))
+				registrationStatusDto.setStatusCode(RegistrationExternalStatusCode.PROCESSED.toString());
+		}
 	}
 
 }

--- a/registration-processor/init/registration-processor-registration-status-service/src/test/resources/application.properties
+++ b/registration-processor/init/registration-processor-registration-status-service/src/test/resources/application.properties
@@ -39,3 +39,7 @@ mosip.auth.adapter.impl.basepackage=io.mosip.kernel.auth.defaultadapter
 
 ida-internal-auth-uri=""
 ida-internal-get-certificate-uri=""
+
+# Cbeff XSD file name in config server
+mosip.kernel.xsdfile=mosip-cbeff.xsd
+mosip.kernel.xsdstorage-uri=file:./src/test/resources/

--- a/registration-processor/init/registration-processor-registration-status-service/src/test/resources/mosip-cbeff.xsd
+++ b/registration-processor/init/registration-processor-registration-status-service/src/test/resources/mosip-cbeff.xsd
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Permission is hereby granted, free of charge in perpetuity, to any person 
+obtaining a copy of the Schema, to use, copy, modify, merge and distribute free
+of charge, copies of the Schema for the purposes of developing, implementing, 
+installing and using software based on the Schema, and to permit persons to 
+whom the Schema is furnished to do so, subject to the following conditions:
+
+THE SCHEMA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SCHEMA OR THE USE OR OTHER DEALINGS IN THE
+SCHEMA. 
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns="http://standards.iso.org/iso-iec/19785/-3/ed-2/" targetNamespace="http://standards.iso.org/iso-iec/19785/-3/ed-2/" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="BIR" type="BIRType"/>
+	<xs:complexType name="BIRType">
+		<xs:sequence>
+			<xs:element name="Version" type="VersionType" minOccurs="0"/>
+			<xs:element name="Jyothi" type="VersionType" minOccurs="1"/>
+			<xs:element name="CBEFFVersion" type="VersionType" minOccurs="0"/>
+			<xs:any namespace="##other" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="BIRInfo" type="BIRInfoType"/>
+			<xs:element name="BDBInfo" type="BDBInfoType" minOccurs="0"/>
+			<xs:element name="SBInfo" type="SBInfoType" minOccurs="0"/>
+			<xs:element name="BIR" type="BIRType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="BDB" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="SB" type="xs:base64Binary" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="VersionType">
+		<xs:sequence>
+			<xs:element name="Major" type="xs:unsignedInt"/>
+			<xs:element name="Minor" type="xs:unsignedInt"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BIRInfoType">
+		<xs:sequence>
+			<xs:element name="Creator" type="xs:string" minOccurs="0"/>
+			<xs:element name="Index" type="UUIDType" minOccurs="0"/>
+			<xs:element name="Payload" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="Integrity" type="xs:boolean"/>
+			<xs:element name="CreationDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="NotValidBefore" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="NotValidAfter" type="xs:dateTime" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BDBInfoType">
+		<xs:sequence>
+			<xs:element name="ChallengeResponse" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="Index" type="UUIDType" minOccurs="0"/>
+			<xs:element name="Format" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="Encryption" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="CreationDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="NotValidBefore" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="NotValidAfter" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="Type" type="MultipleTypesType" minOccurs="0"/>
+			<xs:element name="Subtype" type="SubtypeType" minOccurs="0"/>
+			<xs:element name="Level" type="ProcessedLevelType" minOccurs="0"/>
+			<xs:element name="Product" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="CaptureDevice" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="FeatureExtractionAlgorithm" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="ComparisonAlgorithm" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="CompressionAlgorithm" type="RegistryIDType" minOccurs="0"/>
+			<xs:element name="Purpose" type="PurposeType" minOccurs="0"/>
+			<xs:element name="Quality" type="QualityType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RegistryIDType">
+		<xs:sequence>
+			<xs:element name="Organization" type="xs:string"/>
+			<xs:element name="Type" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SBInfoType">
+		<xs:sequence>
+			<xs:element name="Format" type="RegistryIDType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="QualityScoreType">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="QualityType">
+		<xs:sequence>
+			<xs:element name="Algorithm" type="RegistryIDType"/>
+			<xs:choice>
+				<xs:element name="Score" type="QualityScoreType"/>
+				<xs:element name="QualityCalculationFailed" type="xs:string"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="SingleTypeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Scent"/>
+			<xs:enumeration value="DNA"/>
+			<xs:enumeration value="Ear "/>
+			<xs:enumeration value="Face"/>
+			<xs:enumeration value="Finger"/>
+			<xs:enumeration value="Foot"/>
+			<xs:enumeration value="HandGeometry"/>
+			<xs:enumeration value="Vein"/>
+			<xs:enumeration value="Iris"/>
+			<xs:enumeration value="Retina"/>
+			<xs:enumeration value="Voice"/>
+			<xs:enumeration value="Gait"/>
+			<xs:enumeration value="Keystroke"/>
+			<xs:enumeration value="LipMovement"/>
+			<xs:enumeration value="SignatureSign"/>
+			<xs:enumeration value="Palm"/>
+			<xs:enumeration value="BackOfHand"/>
+			<xs:enumeration value="Wrist"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MultipleTypesType">
+		<xs:list itemType="SingleTypeType"/>
+	</xs:simpleType>
+	<xs:simpleType name="SingleAnySubtypeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Thumb"/>
+			<xs:enumeration value="IndexFinger"/>
+			<xs:enumeration value="MiddleFinger"/>
+			<xs:enumeration value="RingFinger"/>
+			<xs:enumeration value="LittleFinger"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SingleVeinOnlySubtypeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="LeftVein"/>
+			<xs:enumeration value="RightVein"/>
+			<xs:enumeration value="Palm"/>
+			<xs:enumeration value="BackOfHand"/>
+			<xs:enumeration value="Wrist"/>
+			<xs:enumeration value="Reserved1"/>
+			<xs:enumeration value="Reserved2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MultipleAnySubtypesType">
+		<xs:list itemType="SingleAnySubtypeType"/>
+	</xs:simpleType>
+	<xs:simpleType name="MultipleVeinOnlySubtypesType">
+		<xs:list itemType="SingleVeinOnlySubtypeType"/>
+	</xs:simpleType>
+	<xs:simpleType name="SubtypeType">
+		<xs:union memberTypes="MultipleAnySubtypesType MultipleVeinOnlySubtypesType"/>
+	</xs:simpleType>
+	<xs:simpleType name="ProcessedLevelType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Raw"/>
+			<xs:enumeration value="Intermediate"/>
+			<xs:enumeration value="Processed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PurposeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Verify"/>
+			<xs:enumeration value="Identify"/>
+			<xs:enumeration value="Enroll"/>
+			<xs:enumeration value="EnrollVerify"/>
+			<xs:enumeration value="EnrollIdentify"/>
+			<xs:enumeration value="Audit"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UUIDType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-fA-F0-9]{8}\-([a-fA-F0-9]{4}\-){3}[a-fA-F0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/code/RegistrationExternalStatusCode.java
+++ b/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/code/RegistrationExternalStatusCode.java
@@ -21,6 +21,8 @@ public enum RegistrationExternalStatusCode {
 	REPROCESS_FAILED,
 
 	/** The upload pending. */
-	UPLOAD_PENDING
+	UPLOAD_PENDING,
+
+	UIN_GENERATED	
 
 }

--- a/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/dto/InternalRegistrationStatusDto.java
+++ b/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/dto/InternalRegistrationStatusDto.java
@@ -84,8 +84,11 @@ public class InternalRegistrationStatusDto implements Serializable {
 	/** The default resume action. */
 	private String defaultResumeAction;
 
-
+	/** The comma separate tags that will be removed on resume. */
 	private String resumeRemoveTags;
+
+	/** The last success stage name. */
+	private String lastSuccessStageName;
 
 	/**
 	 * Gets the ref id.
@@ -570,6 +573,24 @@ public class InternalRegistrationStatusDto implements Serializable {
 
 	public void setResumeRemoveTags(String resumeRemoveTags) {
 		this.resumeRemoveTags = resumeRemoveTags;
+	}
+
+	/**
+	 * Gets the last success stage name.
+	 *
+	 * @return the last success stage name
+	 */
+	public String getLastSuccessStageName() {
+		return lastSuccessStageName;
+	}
+
+	/**
+	 * Sets the last success stage name.
+	 *
+	 * @param lastSuccessStageName the last success stage name
+	 */
+	public void setLastSuccessStageName(String lastSuccessStageName) {
+		this.lastSuccessStageName = lastSuccessStageName;
 	}
 
 	@Override

--- a/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/entity/RegistrationStatusEntity.java
+++ b/registration-processor/registration-processor-registration-status-service-impl/src/main/java/io/mosip/registration/processor/status/entity/RegistrationStatusEntity.java
@@ -103,9 +103,13 @@ public class RegistrationStatusEntity extends BaseRegistrationEntity {
 	@Column(name = "default_resume_action")
 	private String defaultResumeAction;
 
-	/** The default resume action. */
+	/** The comma separate tags that will be removed on resume. */
 	@Column(name = "resume_remove_tags")
 	private String resumeRemoveTags;
+
+	/** The last success stage name. */
+	@Column(name = "last_success_stage_name")
+	private String lastSuccessStageName;
 
 	/**
 	 * Instantiates a new registration status entity.
@@ -547,6 +551,24 @@ public class RegistrationStatusEntity extends BaseRegistrationEntity {
 	 */
 	public void setResumeRemoveTags(String resumeRemoveTags) {
 		this.resumeRemoveTags = resumeRemoveTags;
+	}
+
+	/**
+	 * Gets the last success stage name.
+	 *
+	 * @return the last success stage name
+	 */
+	public String getLastSuccessStageName() {
+		return lastSuccessStageName;
+	}
+
+	/**
+	 * Sets the last success stage name.
+	 *
+	 * @param lastSuccessStageName the last success stage name
+	 */
+	public void setLastSuccessStageName(String lastSuccessStageName) {
+		this.lastSuccessStageName = lastSuccessStageName;
 	}
 
 }


### PR DESCRIPTION
Changes:
1. Introduced new column called last success stage name to hold the last successfull stage completed by regproc
2. Introduced UIN_GENERATED as a new external status for indicating packet processing is fully completed & UIN generated and external status PROCESSED will indicate that packet has crossed the packet uploader stage
3. Introduced config in registration status service to consider few external status as processed, so regclient can delete the packet even when external status other than processed.
4. Fixed issues related to unit test cases in registration status service 
5. Fixed issues related to unit test cases in packet receiver stage