### PR TITLE
Add ecemped column list for transliteration

### DIFF
--- a/registration/registration-client/src/main/java/io/mosip/registration/controller/reg/DemographicDetailController.java
+++ b/registration/registration-client/src/main/java/io/mosip/registration/controller/reg/DemographicDetailController.java
@@ -1757,14 +1757,9 @@ public class DemographicDetailController extends BaseController {
 					LOGGER.debug(loggerClassName, APPLICATION_NAME, RegistrationConstants.APPLICATION_ID,
 							"Setting secondary langauge text");
 
-					// excempted column list
-					String[] exemptedTransliteration = new String[]{"email", "nationalIdentityNumber", "phoneNumber"};
-					List<String> exemptList = new ArrayList<>(Arrays.asList(exemptedTransliteration));
-
-					if(exemptList.contains(textField.getId())){
-						hasToBeTransliterated = false;
-					} else {
-						hasToBeTransliterated = true;
+					List<String> exemptedTransliteration = applicationContext.getExemptedColumns();
+					if (!exemptedTransliteration.isEmpty()) {
+						hasToBeTransliterated = !exemptedTransliteration.contains(textField.getId());
 					}
 
 					// Set Local lang

--- a/registration/registration-client/src/main/java/io/mosip/registration/controller/reg/DemographicDetailController.java
+++ b/registration/registration-client/src/main/java/io/mosip/registration/controller/reg/DemographicDetailController.java
@@ -1757,6 +1757,16 @@ public class DemographicDetailController extends BaseController {
 					LOGGER.debug(loggerClassName, APPLICATION_NAME, RegistrationConstants.APPLICATION_ID,
 							"Setting secondary langauge text");
 
+					// excempted column list
+					String[] exemptedTransliteration = new String[]{"email", "nationalIdentityNumber", "phoneNumber"};
+					List<String> exemptList = new ArrayList<>(Arrays.asList(exemptedTransliteration));
+
+					if(exemptList.contains(textField.getId())){
+						hasToBeTransliterated = false;
+					} else {
+						hasToBeTransliterated = true;
+					}
+
 					// Set Local lang
 					setSecondaryLangText(textField, localField, hasToBeTransliterated);
 

--- a/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/constants/RegistrationConstants.java
@@ -303,6 +303,8 @@ public class RegistrationConstants {
 	public static final String TOGGLE_BIO_METRIC_EXCEPTION = "toggleBiometricException";
 	public static final String IS_LOW_QUALITY_BIOMETRICS = "Low Quality Biometrics";
 
+	public static final String TRANSLITERATION_EXEMPTED_COLUMNS = "mosip.transliteration-exemptions";
+
 	// Reasons for Exception
 	public static final String MISSING_BIOMETRICS = "Missing biometrics";
 	public static final String LOW_QUALITY_BIOMETRICS = "Low quality of biometrics";

--- a/registration/registration-services/src/main/java/io/mosip/registration/context/ApplicationContext.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/context/ApplicationContext.java
@@ -1,9 +1,6 @@
 package io.mosip.registration.context;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.util.*;
 
 import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.kernel.core.util.StringUtils;
@@ -48,6 +45,9 @@ public class ApplicationContext {
 
 	/** The application languge. */
 	private String applicationLanguge;
+
+	private List<String> exemptedColumn;
+
 
 	/** The primary language right to left. */
 	private boolean primaryLanguageRightToLeft;
@@ -143,6 +143,9 @@ public class ApplicationContext {
 			LOGGER.error("Application Context", RegistrationConstants.APPLICATION_NAME,
 					RegistrationConstants.APPLICATION_ID, exception.getMessage());
 		}
+
+		String exemptedColumnList = (String) applicationMap.get(RegistrationConstants.TRANSLITERATION_EXEMPTED_COLUMNS);
+		exemptedColumn = StringUtils.isNotBlank(exemptedColumnList) ? Arrays.asList(exemptedColumnList.split(",", 0)) : new ArrayList<>();
 
 		String languageSupport = (String) applicationMap.get(RegistrationConstants.LANGUAGE_SUPPORT);
 		if (StringUtils.isNotBlank(languageSupport)) {
@@ -351,6 +354,10 @@ public class ApplicationContext {
 	 */
 	public String getApplicationLanguage() {
 		return applicationLanguge;
+	}
+
+	public List<String> getExemptedColumns() {
+		return exemptedColumn;
 	}
 
 	/**

--- a/registration/registration-services/src/main/java/io/mosip/registration/util/mastersync/ClientSettingSyncHelper.java
+++ b/registration/registration-services/src/main/java/io/mosip/registration/util/mastersync/ClientSettingSyncHelper.java
@@ -604,7 +604,7 @@ public class ClientSettingSyncHelper {
 	private void checkForDuplicates(List<DynamicField> fields, List<DynamicField> existingFields) {
 		for (DynamicField tobeUpdatedField : fields) {
 			for (DynamicField existingField : existingFields) {
-				if(tobeUpdatedField.getName().equalsIgnoreCase(existingField.getName())) {
+				if(tobeUpdatedField.getId().equalsIgnoreCase(existingField.getId())) {
 					dynamicFieldRepository.delete(existingField);
 				}
 			}


### PR DESCRIPTION
Add an exempted column list to handle the columns that do not need to be transliterated in demographic details form