### PR TITLE
MOSIP-15993: Upgrading swagger2 to openapi3.0 in registration processor 

### DIFF
--- a/registration-processor/init/registration-processor-registration-status-service/pom.xml
+++ b/registration-processor/init/registration-processor-registration-status-service/pom.xml
@@ -136,8 +136,8 @@
 							</execution>
 						</executions>
 						<configuration>
-							<apiDocsUrl>http://localhost:8090/app/generic/v3/api-docs</apiDocsUrl>
-							<outputFileName>openapi.json</outputFileName>
+							<apiDocsUrl>http://localhost:8090/app/generic/v3/api-docs.yaml</apiDocsUrl>
+							<outputFileName>openapi.yaml</outputFileName>
 							<outputDir>${project.build.directory}</outputDir>
 							<skip>false</skip>
 						</configuration>

--- a/registration-processor/init/registration-processor-registration-status-service/pom.xml
+++ b/registration-processor/init/registration-processor-registration-status-service/pom.xml
@@ -42,6 +42,11 @@
     		<groupId>org.springframework.security</groupId>
     		<artifactId>spring-security-test</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.5.2</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -64,4 +69,81 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openapi-doc-generate-profile</id>
+			<dependencies>
+				<dependency>
+					<groupId>io.mosip.kernel</groupId>
+					<artifactId>kernel-auth-adapter</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<version>${spring.boot.version}</version>
+						<configuration>
+							<executable>true</executable>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<id>pre-integration-test</id>
+								<goals>
+									<goal>start</goal>
+								</goals>
+								<configuration>
+									<folders>
+										<folder>src/test/resources</folder>
+									</folders>
+									<profiles>
+										<profile>openapi-profile</profile>
+									</profiles>
+									<arguments>
+										<argument>--server.port=8090</argument>
+										<argument>--server.servlet.path=/app/generic</argument>
+									</arguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>post-integration-test</id>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+							<execution>
+								<goals>
+									<goal>build-info</goal>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.springdoc</groupId>
+						<artifactId>springdoc-openapi-maven-plugin</artifactId>
+						<version>0.2</version>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<goals>
+									<goal>generate</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<apiDocsUrl>http://localhost:8090/app/generic/v3/api-docs</apiDocsUrl>
+							<outputFileName>openapi.json</outputFileName>
+							<outputDir>${project.build.directory}</outputDir>
+							<skip>false</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
@@ -10,20 +10,11 @@ import org.springframework.context.annotation.Configuration;
  * The Class RegistrationStatusConfig.
  */
 @Configuration
-//@EnableSwagger2
 public class RegistrationStatusConfig {
 
 	/**
 	 * Registration status bean.
-	 *
-	 * @return the docket
 	 */
-//	@Bean
-//	public Docket registrationStatusBean() {
-//		return new Docket(DocumentationType.SWAGGER_2).select()
-//				.apis(RequestHandlerSelectors.basePackage("io.mosip.registration.processor.status.api.controller"))
-//				.paths(PathSelectors.ant("/*")).build();
-//	}
 	@Bean
 	public OpenAPI customOpenAPI() {
 		return new OpenAPI()
@@ -31,5 +22,5 @@ public class RegistrationStatusConfig {
 				.info(new Info().title("Registration status API").description(
 						"This is a registration status service using springdoc-openapi and OpenAPI 3.").version("3.0.1"));
 	}
-
 }
+

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
@@ -19,8 +19,8 @@ public class RegistrationStatusConfig {
 	public OpenAPI customOpenAPI() {
 		return new OpenAPI()
 				.components(new Components())
-				.info(new Info().title("Registration status API").description(
-						"This is a registration status service using springdoc-openapi and OpenAPI 3.").version("3.0.1"));
+				.info(new Info().title("Registration Status Service API documentation").description(
+						"Registration status service contains the APIs used by registration client and resident services to sync packets and check the status the packets").version("3.0.1"));
 	}
 }
 

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/config/RegistrationStatusConfig.java
@@ -1,19 +1,16 @@
 package io.mosip.registration.processor.status.api.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-	
 /**
  * The Class RegistrationStatusConfig.
  */
 @Configuration
-@EnableSwagger2
+//@EnableSwagger2
 public class RegistrationStatusConfig {
 
 	/**
@@ -21,11 +18,18 @@ public class RegistrationStatusConfig {
 	 *
 	 * @return the docket
 	 */
+//	@Bean
+//	public Docket registrationStatusBean() {
+//		return new Docket(DocumentationType.SWAGGER_2).select()
+//				.apis(RequestHandlerSelectors.basePackage("io.mosip.registration.processor.status.api.controller"))
+//				.paths(PathSelectors.ant("/*")).build();
+//	}
 	@Bean
-	public Docket registrationStatusBean() {
-		return new Docket(DocumentationType.SWAGGER_2).groupName("Registration Status").select()
-				.apis(RequestHandlerSelectors.basePackage("io.mosip.registration.processor.status.api.controller"))
-				.paths(PathSelectors.ant("/*")).build();
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.components(new Components())
+				.info(new Info().title("Registration status API").description(
+						"This is a registration status service using springdoc-openapi and OpenAPI 3.").version("3.0.1"));
 	}
-	
+
 }

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/InternalAuthDelegateServicesController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/InternalAuthDelegateServicesController.java
@@ -4,10 +4,10 @@ import io.mosip.kernel.core.http.ResponseFilter;
 import io.mosip.registration.processor.core.auth.dto.AuthRequestDTO;
 import io.mosip.registration.processor.core.auth.dto.AuthResponseDTO;
 import io.mosip.registration.processor.status.service.InternalAuthDelegateService;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -45,7 +45,9 @@ public class InternalAuthDelegateServicesController {
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN','REGISTRATION_OFFICER','REGISTRATION_SUPERVISOR')")
 	@PostMapping(path = "/auth", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(summary = "Authenticate Internal Request", description = "Authenticate Internal Request", tags = { "Internal Auth Delegate Services" })
-	@ApiResponses(value = { @ApiResponse(code = 200, message = "Request authenticated successfully") })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Request authenticated successfully"),
+			@ApiResponse(responseCode = "401", description = "Unauthorized") })
 	public ResponseEntity<AuthResponseDTO> authenticate(@Validated @RequestBody AuthRequestDTO authRequestDTO,
 			@RequestHeader HttpHeaders headers) throws Exception {
 		return ResponseEntity.status(HttpStatus.OK)

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/InternalAuthDelegateServicesController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/InternalAuthDelegateServicesController.java
@@ -1,7 +1,14 @@
 package io.mosip.registration.processor.status.api.controller;
 
-import java.util.Optional;
-
+import io.mosip.kernel.core.http.ResponseFilter;
+import io.mosip.registration.processor.core.auth.dto.AuthRequestDTO;
+import io.mosip.registration.processor.core.auth.dto.AuthResponseDTO;
+import io.mosip.registration.processor.status.service.InternalAuthDelegateService;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpHeaders;
@@ -10,22 +17,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import io.mosip.kernel.core.http.ResponseFilter;
-import io.mosip.registration.processor.core.auth.dto.AuthRequestDTO;
-import io.mosip.registration.processor.core.auth.dto.AuthResponseDTO;
-import io.mosip.registration.processor.status.service.InternalAuthDelegateService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import java.util.Optional;
 
 /**
  * The Class InternalAuthDelegateServicesController - The controller exposing
@@ -34,7 +28,7 @@ import io.swagger.annotations.ApiResponses;
  */
 @RefreshScope
 @RestController
-@Api(tags = "Internal Auth Delegate Services")
+@Tag(name = "Internal Auth Delegate Services", description = "Internal Auth Delegate Services")
 public class InternalAuthDelegateServicesController {
 
 	/** The internal auth delegate service. */
@@ -50,7 +44,7 @@ public class InternalAuthDelegateServicesController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN','REGISTRATION_OFFICER','REGISTRATION_SUPERVISOR')")
 	@PostMapping(path = "/auth", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Authenticate Internal Request")
+	@Operation(summary = "Authenticate Internal Request", description = "Authenticate Internal Request", tags = { "Internal Auth Delegate Services" })
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Request authenticated successfully") })
 	public ResponseEntity<AuthResponseDTO> authenticate(@Validated @RequestBody AuthRequestDTO authRequestDTO,
 			@RequestHeader HttpHeaders headers) throws Exception {
@@ -69,8 +63,9 @@ public class InternalAuthDelegateServicesController {
 	@PreAuthorize("hasAnyRole('INDIVIDUAL','REGISTRATION_PROCESSOR','REGISTRATION_ADMIN','REGISTRATION_SUPERVISOR','REGISTRATION_OFFICER','PRE_REGISTRATION_ADMIN')")
 	@ResponseFilter
 	@GetMapping(value = "/getCertificate")
-	public Object getCertificate(@ApiParam("Id of application") @RequestParam("applicationId") String applicationId,
-			@ApiParam("Refrence Id as metadata") @RequestParam("referenceId") Optional<String> referenceId, @RequestHeader HttpHeaders headers) throws Exception {
+	@Operation(summary = "getCertificate", description = "getCertificate", tags = { "Internal Auth Delegate Services" })
+	public Object getCertificate(@Parameter(description = "Id of application") @RequestParam("applicationId") String applicationId,
+								 @Parameter(description="Reference Id as metadata") @RequestParam("referenceId") Optional<String> referenceId, @RequestHeader HttpHeaders headers) throws Exception {
 		return internalAuthDelegateService.getCertificate(applicationId, referenceId, headers);
 	}
 

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationExternalStatusController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationExternalStatusController.java
@@ -1,10 +1,20 @@
 package io.mosip.registration.processor.status.api.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.mosip.kernel.core.util.DateUtils;
+import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
+import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
+import io.mosip.registration.processor.status.dto.*;
+import io.mosip.registration.processor.status.exception.RegStatusAppException;
+import io.mosip.registration.processor.status.service.RegistrationStatusService;
+import io.mosip.registration.processor.status.service.SyncRegistrationService;
+import io.mosip.registration.processor.status.sync.response.dto.RegExternalStatusResponseDTO;
+import io.mosip.registration.processor.status.validator.RegistrationExternalStatusRequestValidator;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -18,34 +28,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import io.mosip.kernel.core.util.DateUtils;
-import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
-import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
-import io.mosip.registration.processor.status.code.RegistrationExternalStatusCode;
-import io.mosip.registration.processor.status.dto.ErrorDTO;
-import io.mosip.registration.processor.status.dto.InternalRegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.RegistrationExternalStatusRequestDTO;
-import io.mosip.registration.processor.status.dto.RegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusErrorDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusSubRequestDto;
-import io.mosip.registration.processor.status.dto.SyncRegistrationDto;
-import io.mosip.registration.processor.status.dto.SyncResponseDto;
-import io.mosip.registration.processor.status.exception.RegStatusAppException;
-import io.mosip.registration.processor.status.service.RegistrationStatusService;
-import io.mosip.registration.processor.status.service.SyncRegistrationService;
-import io.mosip.registration.processor.status.sync.response.dto.RegExternalStatusResponseDTO;
-import io.mosip.registration.processor.status.validator.RegistrationExternalStatusRequestValidator;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @RefreshScope
 @RestController
-@Api(tags = "External Registration Status")
+@Tag(name = "External Registration Status", description = "External Registration Status")
 public class RegistrationExternalStatusController {
 	
 	/** The registration status service. */
@@ -82,7 +72,7 @@ public class RegistrationExternalStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'REGISTRATION_SUPERVISOR','RESIDENT')")
 	@PostMapping(path = "/externalstatus/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get the registration external status", response = RegistrationExternalStatusCode.class)
+	@Operation(summary = "Get the registration external status", description = "registration external status", tags = { "External Registration Status" })
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration external status successfully fetched"),
 			@ApiResponse(code = 400, message = "Unable to fetch the registration external status") })
 	public ResponseEntity<Object> search(

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationExternalStatusController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationExternalStatusController.java
@@ -5,16 +5,19 @@ import com.google.gson.GsonBuilder;
 import io.mosip.kernel.core.util.DateUtils;
 import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
 import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
+import io.mosip.registration.processor.status.code.RegistrationExternalStatusCode;
 import io.mosip.registration.processor.status.dto.*;
 import io.mosip.registration.processor.status.exception.RegStatusAppException;
 import io.mosip.registration.processor.status.service.RegistrationStatusService;
 import io.mosip.registration.processor.status.service.SyncRegistrationService;
 import io.mosip.registration.processor.status.sync.response.dto.RegExternalStatusResponseDTO;
 import io.mosip.registration.processor.status.validator.RegistrationExternalStatusRequestValidator;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -32,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 
 @RefreshScope
 @RestController
@@ -72,9 +76,11 @@ public class RegistrationExternalStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'REGISTRATION_SUPERVISOR','RESIDENT')")
 	@PostMapping(path = "/externalstatus/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Operation(summary = "Get the registration external status", description = "registration external status", tags = { "External Registration Status" })
-	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration external status successfully fetched"),
-			@ApiResponse(code = 400, message = "Unable to fetch the registration external status") })
+	@Operation(summary = "Get the registration external status", description = "Get the registration external status", tags = { "External Registration Status" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Registration external status successfully fetched",
+					content = @Content(schema = @Schema(implementation = RegistrationExternalStatusCode.class))),
+			@ApiResponse(responseCode = "400", description = "Unable to fetch the registration external status") })
 	public ResponseEntity<Object> search(
 			@RequestBody(required = true) RegistrationExternalStatusRequestDTO registrationExternalStatusRequestDTO)
 			throws RegStatusAppException {

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
@@ -1,10 +1,22 @@
 package io.mosip.registration.processor.status.api.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.mosip.kernel.core.util.DateUtils;
+import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
+import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
+import io.mosip.registration.processor.status.code.RegistrationExternalStatusCode;
+import io.mosip.registration.processor.status.dto.*;
+import io.mosip.registration.processor.status.exception.RegStatusAppException;
+import io.mosip.registration.processor.status.service.RegistrationStatusService;
+import io.mosip.registration.processor.status.service.SyncRegistrationService;
+import io.mosip.registration.processor.status.sync.response.dto.RegStatusResponseDTO;
+import io.mosip.registration.processor.status.validator.LostRidRequestValidator;
+import io.mosip.registration.processor.status.validator.RegistrationStatusRequestValidator;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -18,41 +30,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import io.mosip.kernel.core.util.DateUtils;
-import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
-import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
-import io.mosip.registration.processor.status.code.RegistrationExternalStatusCode;
-import io.mosip.registration.processor.status.dto.ErrorDTO;
-import io.mosip.registration.processor.status.dto.InternalRegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.LostRidDto;
-import io.mosip.registration.processor.status.dto.LostRidRequestDto;
-import io.mosip.registration.processor.status.dto.LostRidResponseDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusErrorDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusRequestDTO;
-import io.mosip.registration.processor.status.dto.RegistrationStatusSubRequestDto;
-import io.mosip.registration.processor.status.dto.SyncRegistrationDto;
-import io.mosip.registration.processor.status.dto.SyncResponseDto;
-import io.mosip.registration.processor.status.exception.RegStatusAppException;
-import io.mosip.registration.processor.status.service.RegistrationStatusService;
-import io.mosip.registration.processor.status.service.SyncRegistrationService;
-import io.mosip.registration.processor.status.sync.response.dto.RegStatusResponseDTO;
-import io.mosip.registration.processor.status.validator.LostRidRequestValidator;
-import io.mosip.registration.processor.status.validator.RegistrationStatusRequestValidator;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * The Class RegistrationStatusController.
  */
 @RefreshScope
 @RestController
-@Api(tags = "Registration Status")
+@Tag(name = "Registration Status", description = "the Registration Status API")
 public class RegistrationStatusController {
 
 	/** The registration status service. */
@@ -102,7 +90,7 @@ public class RegistrationStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'REGISTRATION_SUPERVISOR','RESIDENT')")
 	@PostMapping(path = "/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get the registration entity", response = RegistrationExternalStatusCode.class)
+	@Operation(summary = "Get the registration entity", description = "registration entity", tags = { "Registration Status" })
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration Entity successfully fetched"),
 			@ApiResponse(code = 400, message = "Unable to fetch the Registration Entity") })
 	public ResponseEntity<Object> search(
@@ -153,7 +141,7 @@ public class RegistrationStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'ZONAL_ADMIN','GLOBAL_ADMIN')")
 	@PostMapping(path = "/lostridsearch", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get the lost registration id", response = RegistrationExternalStatusCode.class)
+	@Operation(summary = "Get the lost registration id", description = "lost registration id", tags = { "Registration Status" })
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration id successfully fetched"),
 			@ApiResponse(code = 400, message = "Unable to fetch the Registration id") })
 	public ResponseEntity<Object> searchLostRid(

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationStatusController.java
@@ -13,9 +13,11 @@ import io.mosip.registration.processor.status.service.SyncRegistrationService;
 import io.mosip.registration.processor.status.sync.response.dto.RegStatusResponseDTO;
 import io.mosip.registration.processor.status.validator.LostRidRequestValidator;
 import io.mosip.registration.processor.status.validator.RegistrationStatusRequestValidator;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 
 /**
  * The Class RegistrationStatusController.
@@ -90,9 +93,11 @@ public class RegistrationStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'REGISTRATION_SUPERVISOR','RESIDENT')")
 	@PostMapping(path = "/search", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Operation(summary = "Get the registration entity", description = "registration entity", tags = { "Registration Status" })
-	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration Entity successfully fetched"),
-			@ApiResponse(code = 400, message = "Unable to fetch the Registration Entity") })
+	@Operation(summary = "Get the registration entity", description = "Get the registration entity", tags = { "Registration Status" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Registration Entity successfully fetched",
+					content = @Content(schema = @Schema(implementation = RegistrationExternalStatusCode.class))),
+			@ApiResponse(responseCode = "400", description = "Unable to fetch the Registration Entity") })
 	public ResponseEntity<Object> search(
 			@RequestBody(required = true) RegistrationStatusRequestDTO registrationStatusRequestDTO)
 			throws RegStatusAppException {
@@ -141,9 +146,13 @@ public class RegistrationStatusController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_OFFICER', 'ZONAL_ADMIN','GLOBAL_ADMIN')")
 	@PostMapping(path = "/lostridsearch", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Operation(summary = "Get the lost registration id", description = "lost registration id", tags = { "Registration Status" })
-	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration id successfully fetched"),
-			@ApiResponse(code = 400, message = "Unable to fetch the Registration id") })
+	@Operation(summary = "Get the lost registration id", description = "Get the lost registration id", tags = { "Registration Status" })
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Registration id successfully fetched",
+					content = @Content(schema = @Schema(implementation = RegistrationExternalStatusCode.class))),
+			@ApiResponse(responseCode = "400", description = "Unable to fetch the Registration Entity") })
+//	@ApiResponses(value = { @ApiResponse(code = 200, message = "Registration id successfully fetched"),
+//			@ApiResponse(code = 400, message = "Unable to fetch the Registration id") })
 	public ResponseEntity<Object> searchLostRid(
 			@RequestBody(required = true) LostRidRequestDto lostRidRequestDto)
 			throws RegStatusAppException {

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationSyncController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationSyncController.java
@@ -1,9 +1,21 @@
 package io.mosip.registration.processor.status.api.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.kernel.core.util.DateUtils;
+import io.mosip.registration.processor.core.constant.ResponseStatusCode;
+import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
+import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
+import io.mosip.registration.processor.status.dto.*;
+import io.mosip.registration.processor.status.exception.RegStatusAppException;
+import io.mosip.registration.processor.status.service.RegistrationStatusService;
+import io.mosip.registration.processor.status.service.SyncRegistrationService;
+import io.mosip.registration.processor.status.sync.response.dto.RegSyncResponseDTO;
+import io.mosip.registration.processor.status.validator.RegistrationSyncRequestValidator;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -17,39 +29,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.mosip.kernel.core.util.DateUtils;
-import io.mosip.registration.processor.core.constant.ResponseStatusCode;
-import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
-import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
-import io.mosip.registration.processor.status.code.RegistrationStatusCode;
-import io.mosip.registration.processor.status.dto.InternalRegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.RegistrationStatusDto;
-import io.mosip.registration.processor.status.dto.RegistrationSyncRequestDTO;
-import io.mosip.registration.processor.status.dto.SyncErrDTO;
-import io.mosip.registration.processor.status.dto.SyncErrorDTO;
-import io.mosip.registration.processor.status.dto.SyncRegistrationDto;
-import io.mosip.registration.processor.status.dto.SyncResponseDto;
-import io.mosip.registration.processor.status.dto.SyncResponseFailDto;
-import io.mosip.registration.processor.status.dto.SyncResponseFailureDto;
-import io.mosip.registration.processor.status.exception.RegStatusAppException;
-import io.mosip.registration.processor.status.service.RegistrationStatusService;
-import io.mosip.registration.processor.status.service.SyncRegistrationService;
-import io.mosip.registration.processor.status.sync.response.dto.RegSyncResponseDTO;
-import io.mosip.registration.processor.status.validator.RegistrationSyncRequestValidator;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The Class RegistrationStatusController.
  */
 @RefreshScope
 @RestController
-@Api(tags = "Registration Status")
+@Tag(name = "Registration Status", description = "the Registration Status API")
 public class RegistrationSyncController {
 
 	/** The registration status service. */
@@ -90,7 +79,7 @@ public class RegistrationSyncController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_PROCESSOR', 'REGISTRATION_OFFICER','REGISTRATION_SUPERVISOR', 'RESIDENT' )")
 	@PostMapping(path = "/sync", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get the synchronizing registration entity", response = RegistrationStatusCode.class)
+	@Operation(summary = "Get the synchronizing registration entity", description = "synchronizing registration entity", tags = { "Registration Status" })
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Synchronizing Registration Entity successfully fetched") })
 	public ResponseEntity<Object> syncRegistrationController(

--- a/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationSyncController.java
+++ b/registration-processor/init/registration-processor-registration-status-service/src/main/java/io/mosip/registration/processor/status/api/controller/RegistrationSyncController.java
@@ -6,15 +6,18 @@ import io.mosip.kernel.core.util.DateUtils;
 import io.mosip.registration.processor.core.constant.ResponseStatusCode;
 import io.mosip.registration.processor.core.exception.util.PlatformErrorMessages;
 import io.mosip.registration.processor.core.util.DigitalSignatureUtility;
+import io.mosip.registration.processor.status.code.RegistrationStatusCode;
 import io.mosip.registration.processor.status.dto.*;
 import io.mosip.registration.processor.status.exception.RegStatusAppException;
 import io.mosip.registration.processor.status.service.RegistrationStatusService;
 import io.mosip.registration.processor.status.service.SyncRegistrationService;
 import io.mosip.registration.processor.status.sync.response.dto.RegSyncResponseDTO;
 import io.mosip.registration.processor.status.validator.RegistrationSyncRequestValidator;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -79,15 +82,15 @@ public class RegistrationSyncController {
 	 */
 	@PreAuthorize("hasAnyRole('REGISTRATION_ADMIN', 'REGISTRATION_PROCESSOR', 'REGISTRATION_OFFICER','REGISTRATION_SUPERVISOR', 'RESIDENT' )")
 	@PostMapping(path = "/sync", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Operation(summary = "Get the synchronizing registration entity", description = "synchronizing registration entity", tags = { "Registration Status" })
+	@Operation(summary = "Get the synchronizing registration entity", description = "Get the synchronizing registration entity", tags = { "Registration Status" })
 	@ApiResponses(value = {
-			@ApiResponse(code = 200, message = "Synchronizing Registration Entity successfully fetched") })
+			@ApiResponse(responseCode = "200", description = "Synchronizing Registration Entity successfully fetched",
+					content = @Content(schema = @Schema(implementation = RegistrationStatusCode.class))),
+			@ApiResponse(responseCode = "401", description = "Unauthorized") })
 	public ResponseEntity<Object> syncRegistrationController(
 			@RequestHeader(name = "Center-Machine-RefId", required = true) String referenceId,
 			@RequestHeader(name = "timestamp", required = true) String timeStamp,
 			@RequestBody(required = true) Object encryptedSyncMetaInfo) throws RegStatusAppException {
-
-
 		try {
 			List<SyncResponseDto> syncResponseList = new ArrayList<>();
 			RegistrationSyncRequestDTO registrationSyncRequestDTO = syncRegistrationService

--- a/registration-processor/init/registration-processor-registration-status-service/src/test/resources/application.properties
+++ b/registration-processor/init/registration-processor-registration-status-service/src/test/resources/application.properties
@@ -45,3 +45,10 @@ ida-internal-get-certificate-uri=""
 # Cbeff XSD file name in config server
 mosip.kernel.xsdfile=mosip-cbeff.xsd
 mosip.kernel.xsdstorage-uri=file:./src/test/resources/
+
+server.port=8083
+server.servlet.path=/registrationprocessor/v1/registrationstatus
+mosip.registration.processor.grace.period=30
+mosip.registration.processor.postalcode.req.url=
+springdoc.packagesToScan=io.mosip.registration.processor.status.api.controller
+springdoc.pathsToMatch=/*

--- a/registration-processor/pom.xml
+++ b/registration-processor/pom.xml
@@ -51,7 +51,7 @@
 		<apache.httpcomponents.version>4.5.6</apache.httpcomponents.version>
 
 		<!-- Swagger -->
-		<swagger.version>2.9.2</swagger.version>
+		<swagger.version>3.0.0</swagger.version>
 
 		<!-- Data Access -->
 		<eclipselink.version>2.5.0</eclipselink.version>


### PR DESCRIPTION
Successfully generated openapi3.0 after upgrading the version of swagger and some related annotations like @Apioperation to @Operation and @Api to @Tag.