### PR TITLE
Enabled external integration service module in build to be included i…

### DIFF
--- a/registration-processor/pre-processor/pom.xml
+++ b/registration-processor/pre-processor/pom.xml
@@ -20,7 +20,7 @@
 		<module>registration-processor-osi-validator-stage</module>
 		<module>registration-processor-packet-uploader-stage</module>
 		<module>registration-processor-external-stage</module>
-		<!-- <module>registration-processor-external-integration-service</module> -->
+		<module>registration-processor-external-integration-service</module>
 		<module>registration-processor-quality-checker-stage</module>
         <module>registration-processor-securezone-notification-stage</module>
 		<module>registration-processor-packet-classifier-stage</module> 


### PR DESCRIPTION
…n next release

Since external integration service is the only service which is not getting built and to simplify release process, external integration service building is enabled