### PR TITLE
[MOSIP-36457] Reprocessor is unable to process the failed packets in credential-requestor-stage in v1.2.0.1

### DIFF
--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
@@ -160,7 +160,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.PRINTING_BUS_IN, MessageBusAddress.PRINTING_BUS_OUT,
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_OUT,
 				messageExpiryTimeLimit);
 	}
 
@@ -174,7 +174,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	@Override
 	public MessageDTO process(MessageDTO object) {
 		TrimExceptionMessage trimeExpMessage = new TrimExceptionMessage();
-		object.setMessageBusAddress(MessageBusAddress.PRINTING_BUS_IN);
+		object.setMessageBusAddress(MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN);
 		object.setInternalError(Boolean.FALSE);
 		object.setIsValid(Boolean.FALSE);
 		LogDescription description = new LogDescription();
@@ -397,7 +397,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	@Override
 	public void start() {
 		router.setRoute(this.postUrl(getVertx(), 
-				MessageBusAddress.PRINTING_BUS_IN, MessageBusAddress.PRINTING_BUS_OUT));
+				MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_OUT));
 		this.createServer(router.getRouter(), getPort());
 	}
 

--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
@@ -160,7 +160,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
-		this.consumeAndSend(mosipEventBus, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_OUT,
+		this.consumeAndSend(mosipEventBus, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_OUT,
 				messageExpiryTimeLimit);
 	}
 
@@ -397,7 +397,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	@Override
 	public void start() {
 		router.setRoute(this.postUrl(getVertx(), 
-				MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_OUT));
+				MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_OUT));
 		this.createServer(router.getRouter(), getPort());
 	}
 

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageBusAddress.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageBusAddress.java
@@ -203,7 +203,7 @@ public class MessageBusAddress implements Serializable {
 	public static final MessageBusAddress CREDENTIAL_REQUESTOR_BUS_IN = new MessageBusAddress("credential-requestor-bus-in");
 
 	/** The Constant PRINTING_BUS_OUT. */
-	public static final MessageBusAddress CREDENTIAL_REQUESTOR_OUT = new MessageBusAddress("credential-requestor-bus-out");
+	public static final MessageBusAddress CREDENTIAL_REQUESTOR_BUS_OUT = new MessageBusAddress("credential-requestor-bus-out");
 
 	/** The Constant PRINTING_BUS_RESEND. */
 	public static final MessageBusAddress PRINTING_BUS_RESEND = new MessageBusAddress("printing-bus-resend");

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageBusAddress.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MessageBusAddress.java
@@ -200,10 +200,10 @@ public class MessageBusAddress implements Serializable {
 			"registration-connector-bus-out");
 
 	/** The Constant PRINTING_BUS_IN. */
-	public static final MessageBusAddress PRINTING_BUS_IN = new MessageBusAddress("printing-bus-in");
+	public static final MessageBusAddress CREDENTIAL_REQUESTOR_BUS_IN = new MessageBusAddress("credential-requestor-bus-in");
 
 	/** The Constant PRINTING_BUS_OUT. */
-	public static final MessageBusAddress PRINTING_BUS_OUT = new MessageBusAddress("printing-bus-out");
+	public static final MessageBusAddress CREDENTIAL_REQUESTOR_OUT = new MessageBusAddress("credential-requestor-bus-out");
 
 	/** The Constant PRINTING_BUS_RESEND. */
 	public static final MessageBusAddress PRINTING_BUS_RESEND = new MessageBusAddress("printing-bus-resend");


### PR DESCRIPTION
Reprocessor is unable to process the failed packets in credential-requestor-stage in v1.2.0.1