### PR TITLE
[MOSIP-41317] Securezone changes to reprocess the packets which went into reprocess due to the unavailability of the packet manager

### DIFF
--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -214,6 +214,8 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 		InternalRegistrationStatusDto registrationStatusDto = new InternalRegistrationStatusDto();
 		TrimExceptionMessage trimMessage = new TrimExceptionMessage();
 		LogDescription description = new LogDescription();
+		messageDTO.setInternalError(Boolean.FALSE);
+		messageDTO.setIsValid(Boolean.FALSE);
 		boolean isTransactionSuccessful = false;
 		try {
 			registrationStatusDto = registrationStatusService.getRegistrationStatus(messageDTO.getRid(),
@@ -281,6 +283,7 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 					description.getCode() + " -- " + messageDTO.getRid(),
 					PlatformErrorMessages.RPR_RGS_REGISTRATION_TABLE_NOT_ACCESSIBLE.getMessage() + e.getMessage()
 							+ ExceptionUtils.getStackTrace(e));
+			messageDTO.setIsValid(Boolean.TRUE);
 			messageDTO.setInternalError(Boolean.TRUE);
 			messageDTO.setRid(registrationStatusDto.getRegistrationId());
 		} catch (Exception e) {


### PR DESCRIPTION
[MOSIP-41317] Securezone changes to reprocess the packets which went into reprocess due to the unavailability of the packet manager

[MOSIP-41317]: https://mosip.atlassian.net/browse/MOSIP-41317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ