### PR TITLE
[MOSIP-43967] Change the deprecated end point for key manager signing and modify the object mapper to remove indentation to support v1.2.0.2 reg client.

### DIFF
--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/digital/signature/dto/JWTSignatureRequestDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/digital/signature/dto/JWTSignatureRequestDto.java
@@ -1,0 +1,61 @@
+package io.mosip.registration.processor.core.digital.signature.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *
+ * @author Md Tarique Azeez
+ * @since 1.3.0-SNAPSHOT
+ *
+ */
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class JWTSignatureRequestDto {
+
+    @NotBlank
+    @ApiModelProperty(notes = "Base64 encoded JSON Data to sign", example = "ewogICAiYW55S2V5IjogIlRlc3QgSnNvbiIKfQ", required = true)
+    private String dataToSign;
+
+    /**
+     * Application id of decrypting module
+     */
+    @ApiModelProperty(notes = "Application id to be used for signing", example = "KERNEL", required = false)
+    private String applicationId;
+
+    /**
+     * Refrence Id
+     */
+    @ApiModelProperty(notes = "Refrence Id", example = "SIGN", required = false)
+    private String referenceId;
+
+    /**
+     * Flag to include payload in  JWT Signature Header
+     */
+    @ApiModelProperty(notes = "Flag to include payload in  JWT Signature Header.", example = "false", required = false)
+    private Boolean includePayload;
+
+    /**
+     * Flag to include certificate in  JWT Signature Header
+     */
+    @ApiModelProperty(notes = "Flag to include certificate in  JWT Signature Header.", example = "false", required = false)
+    private Boolean includeCertificate;
+
+    /**
+     * Flag to include certificate hash in JWT Signature Header
+     */
+    @ApiModelProperty(notes = "Flag to include certificate hash(sha256) in  JWT Signature Header.", example = "false", required = false)
+    private Boolean includeCertHash;
+
+    /**
+     * Certificate URL to include in JWT Signature Header
+     */
+    @ApiModelProperty(notes = "Flag to include certificate URL in  JWT Signature Header.", required = false)
+    private String certificateUrl;
+
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/digital/signature/dto/JWTSignatureResponseDto.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/digital/signature/dto/JWTSignatureResponseDto.java
@@ -1,0 +1,28 @@
+package io.mosip.registration.processor.core.digital.signature.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ *
+ * @author Md Tarique Azeez
+ * @since 1.3.0-SNAPSHOT
+ *
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class JWTSignatureResponseDto {
+
+    /**
+     * encrypted data
+     */
+    private String jwtSignedData;
+
+    /**
+     * response time.
+     */
+    private LocalDateTime timestamp;
+}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/kernel/beans/KernelConfig.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/kernel/beans/KernelConfig.java
@@ -37,7 +37,6 @@ public class KernelConfig {
 		JavaTimeModule javaTimeModule = new JavaTimeModule();
 		objectMapper.registerModule(javaTimeModule);
 		objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-		objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
 		objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 		return objectMapper;
 	}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
@@ -58,6 +58,8 @@ public class DigitalSignatureUtility {
 		regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
 				"DigitalSignatureUtility::getDigitalSignature()::entry");
 
+        String encodedData = CryptoUtil.encodeToURLSafeBase64(data.getBytes(StandardCharsets.UTF_8));
+        regProcLogger.info("DigitalSignatureUtility::getDigitalSignature() :: Encoded data: " + encodedData);
         RequestWrapper<JWTSignatureRequestDto> request = new RequestWrapper<>();
         JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
         jwtSignatureRequestDto.setApplicationId(signApplicationid);
@@ -87,6 +89,8 @@ public class DigitalSignatureUtility {
 			regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
 					"DigitalSignatureUtility::getDigitalSignature()::exit");
 
+            String signature = jwtSignatureResponseDto.getJwtSignedData();
+            regProcLogger.info("DigitalSignatureUtility::getDigitalSignature():: Signature data : " + signature);
             return jwtSignatureResponseDto.getJwtSignedData();
 		} catch (ApisResourceAccessException | IOException e) {
 			regProcLogger.error(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.UIN.toString(), "",

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
@@ -59,7 +59,7 @@ public class DigitalSignatureUtility {
 				"DigitalSignatureUtility::getDigitalSignature()::entry");
 
         String encodedData = CryptoUtil.encodeToURLSafeBase64(data.getBytes(StandardCharsets.UTF_8));
-        regProcLogger.info("DigitalSignatureUtility::getDigitalSignature() :: Encoded data: " + encodedData);
+        regProcLogger.info("#DigitalSignatureUtility::getDigitalSignature() :: Encoded data: " + encodedData);
         RequestWrapper<JWTSignatureRequestDto> request = new RequestWrapper<>();
         JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
         jwtSignatureRequestDto.setApplicationId(signApplicationid);

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/util/DigitalSignatureUtility.java
@@ -58,8 +58,6 @@ public class DigitalSignatureUtility {
 		regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
 				"DigitalSignatureUtility::getDigitalSignature()::entry");
 
-        String encodedData = CryptoUtil.encodeToURLSafeBase64(data.getBytes(StandardCharsets.UTF_8));
-        regProcLogger.info("#DigitalSignatureUtility::getDigitalSignature() :: Encoded data: " + encodedData);
         RequestWrapper<JWTSignatureRequestDto> request = new RequestWrapper<>();
         JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
         jwtSignatureRequestDto.setApplicationId(signApplicationid);
@@ -89,8 +87,6 @@ public class DigitalSignatureUtility {
 			regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
 					"DigitalSignatureUtility::getDigitalSignature()::exit");
 
-            String signature = jwtSignatureResponseDto.getJwtSignedData();
-            regProcLogger.info("DigitalSignatureUtility::getDigitalSignature():: Signature data : " + signature);
             return jwtSignatureResponseDto.getJwtSignedData();
 		} catch (ApisResourceAccessException | IOException e) {
 			regProcLogger.error(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.UIN.toString(), "",

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/util/DigitalSignatureTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/util/DigitalSignatureTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -49,6 +50,7 @@ public class DigitalSignatureTest {
 	}
 
 	@Test
+    @Ignore
 	public void testGetSignature() throws ApisResourceAccessException, IOException {
 		SignResponseDto dto = new SignResponseDto();
 		dto.setSignature(signature);

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/util/DigitalSignatureTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/util/DigitalSignatureTest.java
@@ -2,9 +2,9 @@ package io.mosip.registration.processor.core.util;
 
 import java.io.IOException;
 
+import io.mosip.registration.processor.core.digital.signature.dto.JWTSignatureResponseDto;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -50,11 +50,10 @@ public class DigitalSignatureTest {
 	}
 
 	@Test
-    @Ignore
 	public void testGetSignature() throws ApisResourceAccessException, IOException {
-		SignResponseDto dto = new SignResponseDto();
-		dto.setSignature(signature);
-		ResponseWrapper<SignResponseDto> response = new ResponseWrapper<SignResponseDto>();
+        JWTSignatureResponseDto dto = new JWTSignatureResponseDto();
+		dto.setJwtSignedData(signature);
+		ResponseWrapper<JWTSignatureResponseDto> response = new ResponseWrapper<JWTSignatureResponseDto>();
 		response.setResponse(dto);
 		Mockito.when(registrationProcessorRestService.postApi(Matchers.any(), Matchers.any(), Matchers.any(),
 				Matchers.any(), Matchers.any())).thenReturn(response);


### PR DESCRIPTION
[MOSIP-43967] Change the deprecated end point for key manager signing and modify the object mapper to remove indentation to support v1.2.0.2 reg client.

[MOSIP-43967]: https://mosip.atlassian.net/browse/MOSIP-43967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ