### PR TITLE
[MOSIP-44356] : Reduce packetmanager calls in validator & add per-stage worker pool size override

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
@@ -130,10 +130,6 @@ public class AbisHandlerStage extends MosipVerticleAPIManager {
 	@Value("${registration.processor.abis.targetFPIR}")
 	private String targetFPIR;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
@@ -213,7 +209,7 @@ public class AbisHandlerStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.ABIS_HANDLER_BUS_IN,
 				MessageBusAddress.ABIS_HANDLER_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-abis-handler-stage/src/test/java/io/mosip/registration/processor/abis/handler/stage/test/AbisHandlerStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-handler-stage/src/test/java/io/mosip/registration/processor/abis/handler/stage/test/AbisHandlerStageTest.java
@@ -29,6 +29,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -194,9 +195,10 @@ public class AbisHandlerStageTest {
 
 	@Before
 	public void setUp() throws Exception {
+		ReflectionTestUtils.setField(abisHandlerStage, "environment", new StandardEnvironment());
 		ReflectionTestUtils.setField(abisHandlerStage, "maxResults", "30");
 		ReflectionTestUtils.setField(abisHandlerStage, "targetFPIR", "30");
-		ReflectionTestUtils.setField(abisHandlerStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(abisHandlerStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(abisHandlerStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(abisHandlerStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(abisHandlerStage, "httpProtocol", "http");

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -135,10 +135,6 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 	
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.abis.middleware.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -168,7 +164,7 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 		try {
-			mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+			mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 			this.consume(mosipEventBus, MessageBusAddress.ABIS_MIDDLEWARE_BUS_IN, messageExpiryTimeLimit);
 			abisQueueDetails = utility.getAbisQueueDetails();
 			for (AbisQueueDetails abisQueue : abisQueueDetails) {

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
@@ -22,6 +22,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.abis.queue.dto.AbisQueueDetails;
@@ -179,8 +180,9 @@ public class AbisMiddleWareStageTest {
 	@Before
 	public void setUp() throws RegistrationProcessorCheckedException {
 		MockitoAnnotations.openMocks(this);
+		ReflectionTestUtils.setField(stage, "environment", new StandardEnvironment());
 		ReflectionTestUtils.setField(stage, "messageFormat", "byte");
-		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		InternalRegistrationStatusDto internalRegStatusDto = new InternalRegistrationStatusDto();

--- a/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
@@ -44,10 +44,6 @@ public class BioDedupeStage extends MosipVerticleAPIManager {
 	@Autowired
 	BioDedupeProcessor bioDedupeProcessor;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.bio.dedupe.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -62,7 +58,7 @@ public class BioDedupeStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIO_DEDUPE_BUS_IN, 
 			MessageBusAddress.BIO_DEDUPE_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/test/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStageTest.java
+++ b/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/test/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStageTest.java
@@ -115,7 +115,7 @@ public class BioDedupeStageTest {
 	 */
 	@Test
 	public void testDeployVerticle() {
-		ReflectionTestUtils.setField(bioDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(bioDedupeStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(bioDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(bioDedupeStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(bioDedupeStage, "tracing", Mockito.mock(Tracing.class));
@@ -133,7 +133,7 @@ public class BioDedupeStageTest {
 	
 	@Test
 	public void testStart() {
-		ReflectionTestUtils.setField(bioDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(bioDedupeStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(bioDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(bioDedupeStage, "clusterManagerUrl", "/dummyPath");
 		

--- a/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
+++ b/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
@@ -95,10 +95,6 @@ public class BiometricAuthenticationStage extends MosipVerticleAPIManager {
 	@Value("${mosip.kernel.applicant.type.age.limit}")
 	private String ageLimit;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
@@ -117,7 +113,7 @@ public class BiometricAuthenticationStage extends MosipVerticleAPIManager {
 	private SyncRegistrationService<SyncResponseDto, SyncRegistrationDto> syncRegistrationservice;
 
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_IN,
 				MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/test/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/test/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStageTest.java
@@ -235,7 +235,7 @@ public class BiometricAuthenticationStageTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		ReflectionTestUtils.setField(biometricAuthenticationStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(biometricAuthenticationStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(biometricAuthenticationStage, "ageLimit", "5");

--- a/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/main/java/io/mosip/registration/processor/stages/biometric/extraction/stage/BiometricExtractionStage.java
+++ b/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/main/java/io/mosip/registration/processor/stages/biometric/extraction/stage/BiometricExtractionStage.java
@@ -90,10 +90,6 @@ public class BiometricExtractionStage extends MosipVerticleAPIManager{
 	@Value("${mosip.regproc.biometric.extraction.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
 	
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-	
 	/**partner policy ids */
 	@Value("${biometric.extraction.default.partner.policy.ids}")
 	private String partnerPolicyIdsJson;
@@ -135,7 +131,7 @@ public class BiometricExtractionStage extends MosipVerticleAPIManager{
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_IN,
 				MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/test/java/io/mosip/registration/processor/stages/biometric/extraction/stages/test/BiometricExtractionStageTest.java
+++ b/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/test/java/io/mosip/registration/processor/stages/biometric/extraction/stages/test/BiometricExtractionStageTest.java
@@ -23,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -160,7 +161,8 @@ public class BiometricExtractionStageTest {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void setUp() throws Exception {
-		ReflectionTestUtils.setField(biometricExtractionStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(biometricExtractionStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(biometricExtractionStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(biometricExtractionStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(biometricExtractionStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(biometricExtractionStage, "partnerPolicyIdsJson", "[{'partnerId':'mpartner-default-auth','policyId':'mpolicy-default-auth'},{'partnerId':'mpartner-default-print','policyId':'mpolicy-default-print'},{'partnerId':'mpartner-default-print','policyId':'mpolicy-default-qrcode'},{'partnerId':'mpartner-default-print','policyId':'mpolicy-default-euin'}]" );

--- a/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
@@ -37,10 +37,6 @@ public class DemoDedupeStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 	
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.demo.dedupe.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -58,7 +54,7 @@ public class DemoDedupeStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.DEMO_DEDUPE_BUS_IN, 
 			MessageBusAddress.DEMO_DEDUPE_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/test/java/io/mosip/registrationprocessor/stages/demodedupe/DemoDedupeStageTest.java
+++ b/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/test/java/io/mosip/registrationprocessor/stages/demodedupe/DemoDedupeStageTest.java
@@ -107,7 +107,7 @@ public class DemoDedupeStageTest {
 	 */
 	@Test
 	public void testDeployVerticle() {
-		ReflectionTestUtils.setField(demoDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(demoDedupeStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(demoDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(demoDedupeStage, "clusterManagerUrl", "/dummyPath");
 		demoDedupeStage.deployVerticle();
@@ -124,7 +124,7 @@ public class DemoDedupeStageTest {
 	
 	@Test
 	public void testStart() {
-		ReflectionTestUtils.setField(demoDedupeStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(demoDedupeStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(demoDedupeStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(demoDedupeStage, "clusterManagerUrl", "/dummyPath");
 		

--- a/registration-processor/core-processor/registration-processor-finalization-stage/src/main/java/io/mosip/registration/processor/stages/finalization/stage/FinalizationStage.java
+++ b/registration-processor/core-processor/registration-processor-finalization-stage/src/main/java/io/mosip/registration/processor/stages/finalization/stage/FinalizationStage.java
@@ -73,10 +73,6 @@ public class FinalizationStage extends MosipVerticleAPIManager{
 	@Value("${mosip.regproc.biometric.extraction.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
 	
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-	
 	/** The registration status service. */
 	@Autowired
 	private RegistrationStatusService<String, InternalRegistrationStatusDto, RegistrationStatusDto> registrationStatusService;
@@ -107,7 +103,7 @@ public class FinalizationStage extends MosipVerticleAPIManager{
 	 */
 	public void deployVerticle() {
 		
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.FINALIZATION_BUS_IN,
 				MessageBusAddress.FINALIZATION_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-finalization-stage/src/test/java/io/mosip/registration/processor/stages/finalization/stage/tests/FinalizationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-finalization-stage/src/test/java/io/mosip/registration/processor/stages/finalization/stage/tests/FinalizationStageTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -139,7 +140,8 @@ public class FinalizationStageTest {
 	
 	@Before
 	public void setUp() throws Exception {
-		ReflectionTestUtils.setField(finalizationStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(finalizationStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(finalizationStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(finalizationStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(finalizationStage, "clusterManagerUrl", "/dummyPath");
 

--- a/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/main/java/io/mosip/registration/processor/adjudication/stage/ManualAdjudicationStage.java
+++ b/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/main/java/io/mosip/registration/processor/adjudication/stage/ManualAdjudicationStage.java
@@ -143,10 +143,6 @@ public class ManualAdjudicationStage extends MosipVerticleAPIManager {
 	@Value("${registration.processor.manual.adjudication.queue.url}")
 	private String url;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.manual.adjudication.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -157,7 +153,7 @@ public class ManualAdjudicationStage extends MosipVerticleAPIManager {
 	 * Deploy stage.
 	 */
 	public void deployVerticle() {
-		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consume(mosipEventBus, MessageBusAddress.MANUAL_ADJUDICATION_BUS_IN, messageExpiryTimeLimit);
 		queue = getQueueConnection();
 		if (queue != null) {

--- a/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/test/java/io/mosip/registration/processor/verification/stage/ManualAdjudicationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/test/java/io/mosip/registration/processor/verification/stage/ManualAdjudicationStageTest.java
@@ -134,7 +134,7 @@ public class ManualAdjudicationStageTest {
 		ReflectionTestUtils.setField(manualverificationstage, "mosipConnectionFactory", mosipConnectionFactory);
 		ReflectionTestUtils.setField(manualverificationstage, "mosipQueueManager", mosipQueueManager);
 		//ReflectionTestUtils.setField(manualverificationstage, "contextPath", "/registrationprocessor/v1/manualverification");
-		ReflectionTestUtils.setField(manualverificationstage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(manualverificationstage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(manualverificationstage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(manualverificationstage, "clusterManagerUrl", "/dummyPath");
 		List<String> trustedPackageList=new ArrayList();

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
@@ -144,10 +144,6 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 	@Value("${registration.processor.id.repo.update}")
 	private String idRepoUpdate;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.uin.generator.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -1016,7 +1012,7 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 	 */
 	public void deployVerticle() {
 
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.UIN_GENERATION_BUS_IN,
 				MessageBusAddress.UIN_GENERATION_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
@@ -265,7 +265,7 @@ public class UinGeneratorStageTest {
 
 	@Before
 	public void setup() throws Exception {
-		ReflectionTestUtils.setField(uinGeneratorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(uinGeneratorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(uinGeneratorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(uinGeneratorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(uinGeneratorStage, "updateInfo", "phone");

--- a/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
+++ b/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
@@ -144,10 +144,6 @@ public class VerificationStage extends MosipVerticleAPIManager {
 	@Value("${registration.processor.verification.queue.url}")
 	private String url;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.verification.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -158,7 +154,7 @@ public class VerificationStage extends MosipVerticleAPIManager {
 	 * Deploy stage.
 	 */
 	public void deployVerticle() {
-		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consume(mosipEventBus, MessageBusAddress.VERIFICATION_BUS_IN, messageExpiryTimeLimit);
 		queue = getQueueConnection();
 		if (queue != null) {

--- a/registration-processor/core-processor/registration-processor-verification-stage/src/test/java/io/mosip/registration/processor/verification/service/VerificationServiceTest.java
+++ b/registration-processor/core-processor/registration-processor-verification-stage/src/test/java/io/mosip/registration/processor/verification/service/VerificationServiceTest.java
@@ -34,8 +34,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.ArgumentCaptor;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import io.mosip.kernel.core.util.JsonUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -92,6 +96,7 @@ import io.mosip.registration.processor.verification.util.SaveVerificationRecordU
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*","javax.management.*", "javax.net.ssl.*" })
+@PrepareForTest(JsonUtils.class)
 public class VerificationServiceTest {
 
 	private static final String STAGE_NAME = "VerificationStage";
@@ -539,8 +544,11 @@ public class VerificationServiceTest {
 	}
 
 	@Test
-	public void testSuccessFlowWhenManualVerificationRejectedShouldSetRejectedStatus() throws com.fasterxml.jackson.core.JsonProcessingException {
+	public void testSuccessFlowWhenManualVerificationRejectedShouldSetRejectedStatus() throws Exception {
 
+		PowerMockito.mockStatic(JsonUtils.class);
+		PowerMockito.when(JsonUtils.javaObjectToJsonString(any())).thenReturn("{}");
+		Mockito.when(basePacketRepository.getVerificationRecordByRequestId(resp.getRequestId())).thenReturn(entities);
 		Mockito.when(basePacketRepository.getAssignedVerificationRecord(anyString(), anyString())).thenReturn(entities);
 		String response = objectMapper.writeValueAsString(resp);
 		ActiveMQBytesMessage amq = new ActiveMQBytesMessage();
@@ -559,8 +567,11 @@ public class VerificationServiceTest {
 	}
 
 	@Test
-	public void testSuccessFlowWhenManualVerificationApprovedShouldSetSuccessStatus() throws com.fasterxml.jackson.core.JsonProcessingException {
+	public void testSuccessFlowWhenManualVerificationApprovedShouldSetSuccessStatus() throws Exception {
 
+		PowerMockito.mockStatic(JsonUtils.class);
+		PowerMockito.when(JsonUtils.javaObjectToJsonString(any())).thenReturn("{}");
+		Mockito.when(basePacketRepository.getVerificationRecordByRequestId(resp.getRequestId())).thenReturn(entities);
 		Mockito.when(basePacketRepository.getAssignedVerificationRecord(anyString(), anyString())).thenReturn(entities);
 		String response = objectMapper.writeValueAsString(resp);
 		ActiveMQBytesMessage amq = new ActiveMQBytesMessage();

--- a/registration-processor/core-processor/registration-processor-verification-stage/src/test/java/io/mosip/registration/processor/verification/stage/VerificationStageTest.java
+++ b/registration-processor/core-processor/registration-processor-verification-stage/src/test/java/io/mosip/registration/processor/verification/stage/VerificationStageTest.java
@@ -116,7 +116,7 @@ public class VerificationStageTest {
 		ReflectionTestUtils.setField(verificationstage, "mosipConnectionFactory", mosipConnectionFactory);
 		ReflectionTestUtils.setField(verificationstage, "mosipQueueManager", mosipQueueManager);
 		//ReflectionTestUtils.setField(manualverificationstage, "contextPath", "/registrationprocessor/v1/manualverification");
-		ReflectionTestUtils.setField(verificationstage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(verificationstage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(verificationstage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(verificationstage, "clusterManagerUrl", "/dummyPath");
 		List<String> trustedPackageList = new ArrayList();

--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
@@ -61,10 +61,6 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** The Constant DATETIME_PATTERN. */
 	private static final String DATETIME_PATTERN = "mosip.registration.processor.datetime.pattern";
 
@@ -102,7 +98,7 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	 * deploys this verticle.
 	 */
 	public void deployVerticle() {
-		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 	}
 
 	/** The env. */

--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/test/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStageTest.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/test/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStageTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -115,7 +116,8 @@ public class PacketReceiverStageTest {
 
 	@Before
 	public void setup() throws IOException, io.mosip.kernel.core.exception.IOException {
-		ReflectionTestUtils.setField(packetReceiverStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(packetReceiverStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(packetReceiverStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(packetReceiverStage, "clusterManagerUrl", "/dummyPath");
 		Mockito.when(env.getProperty("mosip.registration.processor.datetime.pattern"))
 		.thenReturn("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");

--- a/registration-processor/pom.xml
+++ b/registration-processor/pom.xml
@@ -66,8 +66,8 @@
 		<h2.version>1.4.195</h2.version>
 		<postgresql.version>42.2.2</postgresql.version>
 
-		<!-- Lombok -->
-		<lombok.version>1.18.8</lombok.version>
+		<!-- Lombok (1.18.38+ fixes TypeTag::UNKNOWN with Java 21+; 1.18.30+ for Java 21) -->
+		<lombok.version>1.18.38</lombok.version>
 
 		<!-- For Cache -->
 		<ignite.version>2.3.0</ignite.version>
@@ -444,9 +444,16 @@
 					<configuration>
 						<source>${maven.compiler.source}</source>
 						<target>${maven.compiler.target}</target>
+						<annotationProcessorPaths>
+							<path>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+								<version>${lombok.version}</version>
+							</path>
+						</annotationProcessorPaths>
 						<compilerArgs>
-                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-        </compilerArgs>
+							<arg>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+						</compilerArgs>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
@@ -109,10 +109,6 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	@Autowired
 	RegistrationStatusService<String, InternalRegistrationStatusDto, RegistrationStatusDto> registrationStatusService;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.credentialrequestor.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -163,7 +159,7 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_OUT,
 				messageExpiryTimeLimit);
 	}

--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/test/java/io/mosip/registrationprocessor/credentialrequestor/test/CredentialRequestorStageTest.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/test/java/io/mosip/registrationprocessor/credentialrequestor/test/CredentialRequestorStageTest.java
@@ -195,7 +195,7 @@ public class CredentialRequestorStageTest {
 		when(env.getProperty("mosip.regproc.credentialrequestor.server.port")).thenReturn("8099");
 		when(env.getProperty("mosip.registration.processor.issuer"))
 				.thenReturn("mpartner-default-digitalcard:PDFCard:RPR_UIN_CARD_TEMPLATE;mpartner-default-print:euin:RPR_UIN_CARD_TEMPLATE");
-		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(stage, "busOutHaltAddresses", Arrays.asList());

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
@@ -160,10 +160,6 @@ public class MessageSenderStage extends MosipVerticleAPIManager {
 	@Autowired
 	private ObjectMapper mapper;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.message.sender.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -180,7 +176,7 @@ public class MessageSenderStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		MosipEventBus mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		MosipEventBus mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consume(mosipEventBus, MessageBusAddress.MESSAGE_SENDER_BUS, messageExpiryTimeLimit);
 	}
 

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/test/java/io/mosip/registration/processor/message/sender/stage/test/MessageSenderStageTest.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/test/java/io/mosip/registration/processor/message/sender/stage/test/MessageSenderStageTest.java
@@ -20,6 +20,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -182,7 +183,8 @@ public class MessageSenderStageTest {
 
 	@Before
 	public void setup() throws Exception {
-		ReflectionTestUtils.setField(stage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(stage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(stage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(stage, "notificationTypes", "SMS|EMAIL");

--- a/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/main/java/io/mosip/registration/processor/stages/app/CMDValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/main/java/io/mosip/registration/processor/stages/app/CMDValidatorStage.java
@@ -34,10 +34,6 @@ public class CMDValidatorStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size is the maximum number of worker threads that will be used by the Vert.x instance */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.cmd-validator.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -47,7 +43,7 @@ public class CMDValidatorStage extends MosipVerticleAPIManager {
 
 
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.CMD_VALIDATOR_BUS_IN, MessageBusAddress.CMD_VALIDATOR_BUS_OUT,
 			messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/test/java/io/mosip/registration/processor/cmdvalidator/CMDValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/test/java/io/mosip/registration/processor/cmdvalidator/CMDValidatorStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -109,8 +110,9 @@ public class CMDValidatorStageTest {
 
 	@Test
 	public void testDeployVerticle() {
-		
-		ReflectionTestUtils.setField(cmdValidatorStage, "workerPoolSize", 10);
+
+		ReflectionTestUtils.setField(cmdValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(cmdValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(cmdValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(cmdValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		cmdValidatorStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/main/java/io/mosip/registration/processor/stages/introducervalidator/IntroducerValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/main/java/io/mosip/registration/processor/stages/introducervalidator/IntroducerValidatorStage.java
@@ -39,13 +39,6 @@ public class IntroducerValidatorStage extends MosipVerticleAPIManager {
 	private String clusterManagerUrl;
 
 	/**
-	 * worker pool size is the maximum number of worker threads that will be used by
-	 * the Vert.x instance
-	 */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
-	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
 	 */
@@ -56,7 +49,7 @@ public class IntroducerValidatorStage extends MosipVerticleAPIManager {
 	MosipEventBus mosipEventBus = null;
 
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.INTRODUCER_VALIDATOR_BUS_IN,
 				MessageBusAddress.INTRODUCER_VALIDATOR_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/test/java/io/mosip/registration/processor/app/IntroducerValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/test/java/io/mosip/registration/processor/app/IntroducerValidatorStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -110,7 +111,8 @@ public class IntroducerValidatorStageTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(introducerValidatorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(introducerValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(introducerValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(introducerValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(introducerValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		introducerValidatorStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/main/java/io/mosip/registration/processor/stages/operatorvalidator/OperatorValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/main/java/io/mosip/registration/processor/stages/operatorvalidator/OperatorValidatorStage.java
@@ -38,13 +38,6 @@ public class OperatorValidatorStage extends MosipVerticleAPIManager {
 	private String clusterManagerUrl;
 
 	/**
-	 * worker pool size is the maximum number of worker threads that will be used by
-	 * the Vert.x instance
-	 */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
-	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
 	 */
@@ -55,7 +48,7 @@ public class OperatorValidatorStage extends MosipVerticleAPIManager {
 	MosipEventBus mosipEventBus = null;
 
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.OPERATOR_VALIDATOR_BUS_IN,
 				MessageBusAddress.OPERATOR_VALIDATOR_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/test/java/io/mosip/registration/processor/app/OperatorValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/test/java/io/mosip/registration/processor/app/OperatorValidatorStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -110,7 +111,8 @@ public class OperatorValidatorStageTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(operatorValidatorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(operatorValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(operatorValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(operatorValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(operatorValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		operatorValidatorStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
@@ -48,10 +48,6 @@ public class PacketClassifierStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size is the maximum number of worker threads that will be used by the Vert.x instance */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	@Value("${mosip.regproc.packet.classifier.eventbus.port}")
 	private String eventBusPort;
 
@@ -66,7 +62,7 @@ public class PacketClassifierStage extends MosipVerticleAPIManager {
 	 * Deploys the vertx verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_CLASSIFIER_BUS_IN,
 				MessageBusAddress.PACKET_CLASSIFIER_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/test/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/test/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -107,8 +108,9 @@ public class PacketClassifierStageTest {
 
 	@Test
 	public void testDeployVerticle() {
-		
-		ReflectionTestUtils.setField(packetClassifierStage, "workerPoolSize", 10);
+
+		ReflectionTestUtils.setField(packetClassifierStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(packetClassifierStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(packetClassifierStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(packetClassifierStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetClassifierStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
@@ -46,10 +46,6 @@ public class PacketUploaderStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.packet.uploader.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -76,7 +72,7 @@ public class PacketUploaderStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl ,workerPoolSize);
+		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_UPLOADER_IN,
 				MessageBusAddress.PACKET_UPLOADER_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/test/java/io/mosip/registration/processor/packet/uploader/stage/test/PacketUploaderStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/test/java/io/mosip/registration/processor/packet/uploader/stage/test/PacketUploaderStageTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -115,7 +116,8 @@ public class PacketUploaderStageTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(packetValidatorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(packetValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(packetValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(packetValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(packetValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetValidatorStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/config/ValidatorConfig.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/config/ValidatorConfig.java
@@ -5,6 +5,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
+import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 
@@ -19,6 +20,7 @@ import org.springframework.core.env.Environment;
 import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.kernel.core.util.exception.JsonProcessingException;
 import io.mosip.registration.processor.core.exception.ApisResourceAccessException;
+import io.mosip.registration.processor.core.exception.PacketManagerException;
 import io.mosip.registration.processor.core.exception.RegistrationProcessorCheckedException;
 import io.mosip.registration.processor.core.logger.RegProcessorLogger;
 import io.mosip.registration.processor.core.packet.dto.applicantcategory.ApplicantTypeDocument;
@@ -154,7 +156,7 @@ public class ValidatorConfig {
 					"loading reference validator", "");
 			return new PacketValidator() {
 				@Override
-				public boolean validate(String registrationId, String process, PacketValidationDto packetValidationDto) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException {
+				public boolean validate(String registrationId, String process, PacketValidationDto packetValidationDto, Map<String, String> metaInfo) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException {
 					return true;
 				}
 			};

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidateProcessor.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidateProcessor.java
@@ -195,11 +195,14 @@ public class PacketValidateProcessor {
 			registrationStatusDto
 					.setLatestTransactionTypeCode(RegistrationTransactionTypeCode.VALIDATE_PACKET.toString());
 			registrationStatusDto.setRegistrationStageName(stageName);
-			setPacketCreatedDateTime(registrationStatusDto);
+			// Fetch metaInfo once and reuse for setPacketCreatedDateTime, validate (biometricsXSDValidation), and reverseDataSync
+			Map<String, String> metaInfo = packetManagerService.getMetaInfo(
+					registrationStatusDto.getRegistrationId(), registrationStatusDto.getRegistrationType(), ProviderStageName.PACKET_VALIDATOR);
+			setPacketCreatedDateTime(registrationStatusDto, metaInfo);
 			boolean isValidSupervisorStatus = isValidSupervisorStatus(object);
 			if (isValidSupervisorStatus) {
 				Boolean isValid = compositePacketValidator.validate(object.getRid(),
-						registrationStatusDto.getRegistrationType(), packetValidationDto);
+						registrationStatusDto.getRegistrationType(), packetValidationDto, metaInfo);
 
 				if (isValid) {
 					// save audit details
@@ -223,9 +226,9 @@ public class PacketValidateProcessor {
 							.setStatusComment(StatusUtil.PACKET_STRUCTURAL_VALIDATION_SUCCESS.getMessage());
 					registrationStatusDto.setSubStatusCode(StatusUtil.PACKET_STRUCTURAL_VALIDATION_SUCCESS.getCode());
 					registrationStatusDto.setStatusCode(RegistrationStatusCode.PROCESSING.toString());
-					// ReverseDataSync
+					// ReverseDataSync (reuse metaInfo to avoid second getMetaInfo call)
 					reverseDataSync(registrationId, registrationStatusDto.getRegistrationType(), description,
-							packetValidationDto);
+							packetValidationDto, metaInfo);
 
 					packetValidationDto.setTransactionSuccessful(true);
 					description.setMessage(
@@ -464,10 +467,12 @@ public class PacketValidateProcessor {
 	}
 
 
-	private void setPacketCreatedDateTime(InternalRegistrationStatusDto registrationStatusDto) throws ApisResourceAccessException, PacketManagerException, JsonProcessingException, IOException {
+	private void setPacketCreatedDateTime(InternalRegistrationStatusDto registrationStatusDto, Map<String, String> metaInfo) throws ApisResourceAccessException, PacketManagerException, JsonProcessingException, IOException {
 		try {
-			Map<String, String> metaInfo = packetManagerService.getMetaInfo(
-					registrationStatusDto.getRegistrationId(), registrationStatusDto.getRegistrationType(), ProviderStageName.PACKET_VALIDATOR);
+			if (metaInfo == null) {
+				metaInfo = packetManagerService.getMetaInfo(
+						registrationStatusDto.getRegistrationId(), registrationStatusDto.getRegistrationType(), ProviderStageName.PACKET_VALIDATOR);
+			}
 			DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateformat);
 			String packetCreatedDateTime = metaInfo.get(JsonConstant.CREATIONDATE);
 			if (packetCreatedDateTime != null && !packetCreatedDateTime.isEmpty()) {
@@ -503,11 +508,12 @@ public class PacketValidateProcessor {
 
 	@SuppressWarnings("unchecked")
 	private void reverseDataSync(String id, String process, LogDescription description,
-			PacketValidationDto packetValidationDto) throws IOException, ApisResourceAccessException,
+			PacketValidationDto packetValidationDto, Map<String, String> metaInfoMap) throws IOException, ApisResourceAccessException,
 			PacketManagerException, JsonProcessingException, JSONException {
 
-		Map<String, String> metaInfoMap = packetManagerService.getMetaInfo(id, process,
-				ProviderStageName.PACKET_VALIDATOR);
+		if (metaInfoMap == null) {
+			metaInfoMap = packetManagerService.getMetaInfo(id, process, ProviderStageName.PACKET_VALIDATOR);
+		}
 		String metadata = metaInfoMap.get(JsonConstant.METADATA);
 		if (StringUtils.isNotEmpty(metadata)) {
 			JSONArray jsonArray = new JSONArray(metadata);

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
@@ -46,10 +46,6 @@ public class PacketValidatorStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/** After this time intervel, message should be considered as expired (In seconds). */
 	@Value("${mosip.regproc.packet.validator.message.expiry-time-limit}")
 	private Long messageExpiryTimeLimit;
@@ -66,7 +62,7 @@ public class PacketValidatorStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.PACKET_VALIDATOR_BUS_IN,
 				MessageBusAddress.PACKET_VALIDATOR_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/validator/impl/CompositePacketValidator.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/validator/impl/CompositePacketValidator.java
@@ -1,6 +1,7 @@
 package io.mosip.registration.processor.stages.validator.impl;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,10 +30,11 @@ public class CompositePacketValidator implements PacketValidator {
     private PacketValidator referenceValidatorImpl;
 
     @Override
-    public boolean validate(String id, String process, PacketValidationDto packetValidationDto) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException {
-        boolean isValid = packetValidatorImpl.validate(id, process, packetValidationDto);
-        if (isValid)
-            isValid = referenceValidatorImpl.validate(id, process, packetValidationDto);
+    public boolean validate(String id, String process, PacketValidationDto packetValidationDto, Map<String, String> metaInfo) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException {
+        boolean isValid = packetValidatorImpl.validate(id, process, packetValidationDto, metaInfo);
+        if (isValid && referenceValidatorImpl != null) {
+            isValid = referenceValidatorImpl.validate(id, process, packetValidationDto, metaInfo);
+        }
         return isValid;
     }
 }

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/validator/impl/PacketValidatorImpl.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/validator/impl/PacketValidatorImpl.java
@@ -82,7 +82,7 @@ public class PacketValidatorImpl implements PacketValidator {
     private ApplicantDocumentValidation applicantDocumentValidation;
 
     @Override
-    public boolean validate(String id, String process, PacketValidationDto packetValidationDto)
+    public boolean validate(String id, String process, PacketValidationDto packetValidationDto, Map<String, String> metaInfo)
             throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException,
             JsonProcessingException, PacketManagerException {
         String uin = null;
@@ -163,7 +163,7 @@ public class PacketValidatorImpl implements PacketValidator {
                 }
             }
 
-            if (!biometricsXSDValidation(id, process, packetValidationDto)) {
+            if (!biometricsXSDValidation(id, process, packetValidationDto, metaInfo)) {
                 return false;
             }
         } catch(PacketManagerNonRecoverableException e){
@@ -186,15 +186,16 @@ public class PacketValidatorImpl implements PacketValidator {
         return packetValidationDto.isValid();
     }
 
-    private boolean biometricsXSDValidation(String id, String process, PacketValidationDto packetValidationDto)
+    private boolean biometricsXSDValidation(String id, String process, PacketValidationDto packetValidationDto, Map<String, String> metaInfoMap)
             throws ApisResourceAccessException, PacketManagerException, JsonProcessingException, IOException,
             RegistrationProcessorCheckedException, JSONException {
         List<String> fields = Arrays.asList(MappingJsonConstants.INDIVIDUAL_BIOMETRICS,
                 MappingJsonConstants.AUTHENTICATION_BIOMETRICS, MappingJsonConstants.INTRODUCER_BIO,
                 MappingJsonConstants.OFFICERBIOMETRICFILENAME, MappingJsonConstants.SUPERVISORBIOMETRICFILENAME);
 
-        Map<String, String> metaInfoMap = packetManagerService.getMetaInfo(id, process,
-                ProviderStageName.PACKET_VALIDATOR);
+        if (metaInfoMap == null) {
+            metaInfoMap = packetManagerService.getMetaInfo(id, process, ProviderStageName.PACKET_VALIDATOR);
+        }
 
         for (String field : fields) {
             BiometricRecord biometricRecord = null;

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidateProcessorTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidateProcessorTest.java
@@ -223,7 +223,7 @@ public class PacketValidateProcessorTest {
 		hashsequence2.setValue(sequence2);
 		fieldValueArrayListSequence.add(hashsequence2);
 		PowerMockito.mockStatic(JsonUtil.class);
-		Mockito.when(packetValidator.validate(any(), any(),any())).thenReturn(true);
+		Mockito.when(packetValidator.validate(any(), any(), any(), any())).thenReturn(true);
 		Mockito.doNothing().when(auditUtility).saveAuditDetails(anyString(), anyString());
 		
 		MainResponseDTO<ReverseDatasyncReponseDTO> mainResponseDTO = new MainResponseDTO<>();
@@ -299,7 +299,7 @@ public class PacketValidateProcessorTest {
 	@Test
 	public void PacketValidationFailureTest() throws PacketValidatorException, ApisResourceAccessException, JsonProcessingException, RegistrationProcessorCheckedException, IOException, PacketManagerException {
 		registrationStatusDto.setRetryCount(1);
-		Mockito.when(packetValidator.validate(any(), any(),any())).thenReturn(false);
+		Mockito.when(packetValidator.validate(any(), any(), any(), any())).thenReturn(false);
 		MessageDTO object = packetValidateProcessor.process(messageDTO, stageName);
 		assertFalse(object.getIsValid());
 		assertFalse(object.getInternalError());
@@ -341,7 +341,7 @@ public class PacketValidateProcessorTest {
 	@Test
 	public void PacketValidationAPIResourceExceptionTest() throws PacketValidatorException, ApisResourceAccessException, JsonProcessingException, RegistrationProcessorCheckedException, IOException, PacketManagerException {
 		ApisResourceAccessException exc=new ApisResourceAccessException("Ex");
-		Mockito.when(packetValidator.validate(any(),any(), any())).thenThrow(exc);
+		Mockito.when(packetValidator.validate(any(), any(), any(), any())).thenThrow(exc);
 		Mockito.when(registrationStatusMapperUtil
 				.getStatusCode(RegistrationExceptionTypeCode.APIS_RESOURCE_ACCESS_EXCEPTION)).thenReturn("REPROCESS");
 		MessageDTO object = packetValidateProcessor.process(messageDTO, stageName);
@@ -352,7 +352,7 @@ public class PacketValidateProcessorTest {
 	@Test
 	public void PacketValidationIOExceptionTest() throws PacketValidatorException, ApisResourceAccessException, JsonProcessingException, RegistrationProcessorCheckedException, IOException, PacketManagerException {
 		IOException exc=new IOException("Ex");
-		Mockito.when(packetValidator.validate(any(),any(), any())).thenThrow(exc);
+		Mockito.when(packetValidator.validate(any(), any(), any(), any())).thenThrow(exc);
 		Mockito.when(registrationStatusMapperUtil
 				.getStatusCode(RegistrationExceptionTypeCode.IOEXCEPTION)).thenReturn("ERROR");
 		MessageDTO object = packetValidateProcessor.process(messageDTO, stageName);
@@ -363,7 +363,7 @@ public class PacketValidateProcessorTest {
 	@Test
 	public void PacketValidationBaseCheckedExceptionTest() throws PacketValidatorException, ApisResourceAccessException, JsonProcessingException, RegistrationProcessorCheckedException, IOException, PacketManagerException {
 		RegistrationProcessorCheckedException exc=new RegistrationProcessorCheckedException("", "", new RegistrationProcessorCheckedException("", ""));
-		Mockito.when(packetValidator.validate(any(), any(),any())).thenThrow(exc);
+		Mockito.when(packetValidator.validate(any(), any(), any(), any())).thenThrow(exc);
 		Mockito.when(registrationStatusMapperUtil
 				.getStatusCode(RegistrationExceptionTypeCode.BASE_CHECKED_EXCEPTION)).thenReturn("ERROR");
 		MessageDTO object = packetValidateProcessor.process(messageDTO, stageName);

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -112,7 +113,8 @@ public class PacketValidatorStageTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(packetValidatorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(packetValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(packetValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(packetValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(packetValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		packetValidatorStage.deployVerticle();

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/validator/CompositePacketValidatorTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/validator/CompositePacketValidatorTest.java
@@ -39,8 +39,8 @@ public class CompositePacketValidatorTest {
 	public void validateSuccessTest() throws ApisResourceAccessException, RegistrationProcessorCheckedException,
 			JsonProcessingException, PacketManagerException, IOException {
 
-		Mockito.when(packetValidatorImpl.validate(anyString(), anyString(), any())).thenReturn(true);
-		Mockito.when(referenceValidatorImpl.validate(anyString(), anyString(), any())).thenReturn(true);
+		Mockito.when(packetValidatorImpl.validate(anyString(), anyString(), any(), any())).thenReturn(true);
+		Mockito.when(referenceValidatorImpl.validate(anyString(), anyString(), any(), any())).thenReturn(true);
 		boolean result = compositePacketValidator.validate("10011100120000620210727102631", "NEW", packetValidationDto);
 		assertEquals(result, true);
 	}
@@ -49,7 +49,7 @@ public class CompositePacketValidatorTest {
 	public void validateFailureTest() throws ApisResourceAccessException, RegistrationProcessorCheckedException,
 			JsonProcessingException, PacketManagerException, IOException {
 
-		Mockito.when(packetValidatorImpl.validate(anyString(), anyString(), any())).thenReturn(false);
+		Mockito.when(packetValidatorImpl.validate(anyString(), anyString(), any(), any())).thenReturn(false);
 		boolean result = compositePacketValidator.validate("10011100120000620210727102631", "NEW", packetValidationDto);
 		assertEquals(result, false);
 	}

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/validator/CompositeValidatorTest.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/test/java/io/mosip/registration/processor/stages/validator/CompositeValidatorTest.java
@@ -35,8 +35,8 @@ public class CompositeValidatorTest {
 	 
 	 @Test
 	 public void validateTest() throws ApisResourceAccessException, RegistrationProcessorCheckedException, JsonProcessingException, PacketManagerException, IOException {
-		 Mockito.when(packetValidatorImpl.validate(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
-		 Mockito.when(referenceValidatorImpl.validate(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
+		 Mockito.when(packetValidatorImpl.validate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
+		 Mockito.when(referenceValidatorImpl.validate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
 		 assertTrue(compositePacketValidator.validate("1234", "NEW", new PacketValidationDto()));
 	 }
 	 	

--- a/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/main/java/io/mosip/registration/processor/quality/classifier/stage/QualityClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/main/java/io/mosip/registration/processor/quality/classifier/stage/QualityClassifierStage.java
@@ -100,10 +100,6 @@ public class QualityClassifierStage extends MosipVerticleAPIManager {
 	@Value("${vertx.cluster.configuration}")
 	private String clusterManagerUrl;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
@@ -186,7 +182,7 @@ public class QualityClassifierStage extends MosipVerticleAPIManager {
 	private void generateParsedQualityRangeMap() {
 		parsedQualityRangeMap = new HashMap<>();
 		//If maxPoolSize is not provided then ForkJoinPool will be created with workerPoolSize, so that each work thread utilizes one thread from pool for task execution i.e. equivalent to execute task sequentially inside a worker thread.
-		forkJoinPool = new ForkJoinPool((maxPoolSize > 0 ? maxPoolSize : workerPoolSize));
+		forkJoinPool = new ForkJoinPool((maxPoolSize > 0 ? maxPoolSize : getWorkerPoolSize()));
 		for (Map.Entry<String, String> entry : qualityClassificationRangeMap.entrySet()) {
 			String[] range = entry.getValue().split(RANGE_DELIMITER);
 			int[] rangeArray = new int[2];
@@ -200,7 +196,7 @@ public class QualityClassifierStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.QUALITY_CLASSIFIER_BUS_IN,
 				MessageBusAddress.QUALITY_CLASSIFIER_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/test/java/io/mosip/registration/processor/quality/qualifier/stage/test/QualityClassifierStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/test/java/io/mosip/registration/processor/quality/qualifier/stage/test/QualityClassifierStageTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.kernel.biometrics.constant.BiometricFunction;
@@ -181,7 +182,8 @@ public class QualityClassifierStageTest {
 
 	@Before
 	public void setUp() throws Exception {
-		ReflectionTestUtils.setField(qualityClassifierStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(qualityClassifierStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(qualityClassifierStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(qualityClassifierStage, "maxPoolSize", 10);
 		ReflectionTestUtils.setField(qualityClassifierStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(qualityClassifierStage, "messageExpiryTimeLimit", Long.valueOf(0));

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -70,12 +70,6 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 	private String clusterManagerUrl;
 
 	/**
-	 * worker pool size.
-	 */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
-	/**
 	 * The mosip event bus.
 	 */
 	private MosipEventBus mosipEventBus;
@@ -120,7 +114,7 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		this.mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
 				MessageBusAddress.SECUREZONE_NOTIFICATION_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/test/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/test/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStageTest.java
@@ -413,7 +413,7 @@ public class SecurezoneNotificationStageTest {
         entity1.setWorkflowInstanceId("78fc3d34-03f5-11ec-9a03-0242ac130003");
 
         ctx = setContext();
-        ReflectionTestUtils.setField(notificationStage, "workerPoolSize", 10);
+        ReflectionTestUtils.setField(notificationStage, "defaultWorkerPoolSize", 10);
         ReflectionTestUtils.setField(notificationStage, "clusterManagerUrl", "/dummyPath");
         ReflectionTestUtils.setField(notificationStage, "messageExpiryTimeLimit", Long.valueOf(0));
         ReflectionTestUtils.setField(notificationStage, "mainProcesses", Arrays.asList("NEW","UPDATE","LOST"));

--- a/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/main/java/io/mosip/registration/processor/stages/supervisorvalidator/SupervisorValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/main/java/io/mosip/registration/processor/stages/supervisorvalidator/SupervisorValidatorStage.java
@@ -38,13 +38,6 @@ public class SupervisorValidatorStage extends MosipVerticleAPIManager {
 	private String clusterManagerUrl;
 
 	/**
-	 * worker pool size is the maximum number of worker threads that will be used by
-	 * the Vert.x instance
-	 */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
-	/**
 	 * After this time intervel, message should be considered as expired (In
 	 * seconds).
 	 */
@@ -55,7 +48,7 @@ public class SupervisorValidatorStage extends MosipVerticleAPIManager {
 	MosipEventBus mosipEventBus = null;
 
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consumeAndSend(mosipEventBus, MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_IN,
 				MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_OUT, messageExpiryTimeLimit);
 	}

--- a/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/test/java/io/mosip/registration/processor/app/SupervisorValidatorStageTest.java
+++ b/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/test/java/io/mosip/registration/processor/app/SupervisorValidatorStageTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.registration.processor.core.abstractverticle.EventDTO;
@@ -110,7 +111,8 @@ public class SupervisorValidatorStageTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(supervisorValidatorStage, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(supervisorValidatorStage, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(supervisorValidatorStage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(supervisorValidatorStage, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(supervisorValidatorStage, "messageExpiryTimeLimit", Long.valueOf(0));
 		supervisorValidatorStage.deployVerticle();

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleAPIManager.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleAPIManager.java
@@ -66,6 +66,26 @@ public abstract class MosipVerticleAPIManager extends MosipVerticleManager {
 	@Value("${mosip.regproc.health-check.handler-timeout:2000}")
 	private long healthCheckTimeOut;
 
+	/** Default worker pool size; can be overridden per stage via {getPropertyPrefix()}worker.pool.size */
+	@Value("${worker.pool.size}")
+	private Integer defaultWorkerPoolSize;
+
+	/**
+	 * Returns worker pool size for this stage. Resolves per-stage override from
+	 * {getPropertyPrefix()}worker.pool.size first; if not set, returns default from worker.pool.size.
+	 */
+	protected int getWorkerPoolSize() {
+		String key = getPropertyPrefix() + "worker.pool.size";
+		String override = environment.getProperty(key);
+		if (override != null && !override.trim().isEmpty()) {
+			try {
+				return Integer.parseInt(override.trim());
+			} catch (NumberFormatException e) {
+				return defaultWorkerPoolSize != null ? defaultWorkerPoolSize : 1;
+			}
+		}
+		return defaultWorkerPoolSize != null ? defaultWorkerPoolSize : 1;
+	}
 
 	/**
 	 * This method creates a body handler for the routes

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/packet/validator/PacketValidator.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/packet/validator/PacketValidator.java
@@ -8,8 +8,20 @@ import io.mosip.registration.processor.core.exception.RegistrationProcessorCheck
 import io.mosip.registration.processor.core.packet.dto.packetvalidator.PacketValidationDto;
 
 import java.io.IOException;
+import java.util.Map;
 
 public interface PacketValidator {
 
-	boolean validate(String registrationId, String process, PacketValidationDto packetValidationDto) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException;
+	/**
+	 * Validate packet. Default implementation delegates to {@link #validate(String, String, PacketValidationDto, Map)} with null metaInfo.
+	 */
+	default boolean validate(String registrationId, String process, PacketValidationDto packetValidationDto) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException {
+		return validate(registrationId, process, packetValidationDto, null);
+	}
+
+	/**
+	 * Validate packet with optional pre-fetched metaInfo to avoid redundant packet-manager getMetaInfo calls.
+	 * When metaInfo is null, implementors fetch it internally.
+	 */
+	boolean validate(String registrationId, String process, PacketValidationDto packetValidationDto, Map<String, String> metaInfo) throws ApisResourceAccessException, RegistrationProcessorCheckedException, IOException, JsonProcessingException, PacketManagerException;
 }

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleAPIManagerWorkerPoolSizeTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/abstractverticle/MosipVerticleAPIManagerWorkerPoolSizeTest.java
@@ -1,0 +1,86 @@
+package io.mosip.registration.processor.core.abstractverticle;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link MosipVerticleAPIManager#getWorkerPoolSize()} behaviour:
+ * default from worker.pool.size vs per-stage override from {getPropertyPrefix()}worker.pool.size.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MosipVerticleAPIManagerWorkerPoolSizeTest {
+
+	private static final String STAGE_PREFIX = "mosip.regproc.test.stage.";
+	private static final String OVERRIDE_KEY = STAGE_PREFIX + "worker.pool.size";
+
+	private TestMosipVerticleAPIManager manager;
+
+	private static class TestMosipVerticleAPIManager extends MosipVerticleAPIManager {
+		@Override
+		protected String getPropertyPrefix() {
+			return STAGE_PREFIX;
+		}
+
+		@Override
+		public MessageDTO process(MessageDTO object) {
+			return object;
+		}
+	}
+
+	@Before
+	public void setUp() {
+		manager = new TestMosipVerticleAPIManager();
+		ReflectionTestUtils.setField(manager, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(manager, "defaultWorkerPoolSize", 10);
+	}
+
+	@Test
+	public void getWorkerPoolSize_whenNoOverride_returnsDefault() {
+		assertEquals(10, manager.getWorkerPoolSize());
+	}
+
+	@Test
+	public void getWorkerPoolSize_whenOverrideSet_returnsOverride() {
+		ReflectionTestUtils.setField(manager, "environment", new StandardEnvironment() {
+			@Override
+			public String getProperty(String key) {
+				return OVERRIDE_KEY.equals(key) ? "20" : super.getProperty(key);
+			}
+		});
+		assertEquals(20, manager.getWorkerPoolSize());
+	}
+
+	@Test
+	public void getWorkerPoolSize_whenOverrideEmpty_returnsDefault() {
+		ReflectionTestUtils.setField(manager, "environment", new StandardEnvironment() {
+			@Override
+			public String getProperty(String key) {
+				return OVERRIDE_KEY.equals(key) ? "" : super.getProperty(key);
+			}
+		});
+		assertEquals(10, manager.getWorkerPoolSize());
+	}
+
+	@Test
+	public void getWorkerPoolSize_whenOverrideInvalid_returnsDefault() {
+		ReflectionTestUtils.setField(manager, "environment", new StandardEnvironment() {
+			@Override
+			public String getProperty(String key) {
+				return OVERRIDE_KEY.equals(key) ? "not-a-number" : super.getProperty(key);
+			}
+		});
+		assertEquals(10, manager.getWorkerPoolSize());
+	}
+
+	@Test
+	public void getWorkerPoolSize_whenDefaultNullAndNoOverride_returnsOne() {
+		ReflectionTestUtils.setField(manager, "defaultWorkerPoolSize", null);
+		assertEquals(1, manager.getWorkerPoolSize());
+	}
+}

--- a/registration-processor/workflow-engine/registration-processor-reprocessor/src/test/java/io/mosip/registration/processor/reprocessor/verticle/ReprocessingSchedulerTest.java
+++ b/registration-processor/workflow-engine/registration-processor-reprocessor/src/test/java/io/mosip/registration/processor/reprocessor/verticle/ReprocessingSchedulerTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -76,6 +78,8 @@ public class ReprocessingSchedulerTest {
 		fooLogger = (Logger) LoggerFactory.getLogger(ReprocessorVerticle.class);
 		listAppender = new ListAppender<>();
 		Mockito.when(vertx.eventBus()).thenReturn(Vertx.vertx().eventBus());
+		ReflectionTestUtils.setField(reprocessorVerticle, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(reprocessorVerticle, "clusterManagerUrl", "/dummyPath");
 	}
 
 	/**

--- a/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/main/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionApi.java
+++ b/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/main/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionApi.java
@@ -57,10 +57,6 @@ public class WorkflowActionApi extends MosipVerticleAPIManager {
 
     @Autowired
     WorkflowInstanceApi workflowInstanceApi;
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	@Value("${mosip.regproc.workflow-manager.workflowaction.eventbus.port}")
 	private String eventBusPort;
 
@@ -110,7 +106,7 @@ public class WorkflowActionApi extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 
 
 	}

--- a/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/main/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowInternalActionVerticle.java
+++ b/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/main/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowInternalActionVerticle.java
@@ -93,10 +93,6 @@ public class WorkflowInternalActionVerticle extends MosipVerticleAPIManager {
 	@Value("${mosip.regproc.workflow-manager.internal.action.server.port}")
 	private String port;
 
-	/** worker pool size. */
-	@Value("${worker.pool.size}")
-	private Integer workerPoolSize;
-
 	@Value("${mosip.regproc.workflow-manager.internal.action.eventbus.port}")
 	private String eventBusPort;
 
@@ -147,7 +143,7 @@ public class WorkflowInternalActionVerticle extends MosipVerticleAPIManager {
 	 * Deploy verticle.
 	 */
 	public void deployVerticle() {
-		mosipEventBus = this.getEventBus(this, clusterManagerUrl, workerPoolSize);
+		mosipEventBus = this.getEventBus(this, clusterManagerUrl, getWorkerPoolSize());
 		this.consume(mosipEventBus, MessageBusAddress.WORKFLOW_INTERNAL_ACTION_ADDRESS, 0);
 	}
 

--- a/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionApiTest.java
+++ b/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionApiTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -425,7 +426,7 @@ public class WorkflowActionApiTest {
 
 	@Before
 	public void setup() throws WorkflowActionRequestValidationException {
-		ReflectionTestUtils.setField(workflowActionApi, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(workflowActionApi, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(workflowActionApi, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(workflowActionApi, "dateTimePattern", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 		ctx = setContext();
@@ -447,7 +448,8 @@ public class WorkflowActionApiTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(workflowActionApi, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(workflowActionApi, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(workflowActionApi, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(workflowActionApi, "clusterManagerUrl", "/dummyPath");
 		workflowActionApi.deployVerticle();
 	}

--- a/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionJobSchedularTest.java
+++ b/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowActionJobSchedularTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import ch.qos.logback.classic.Level;
@@ -67,6 +68,7 @@ public class WorkflowActionJobSchedularTest {
 	public void setup() {
 		fooLogger = (Logger) LoggerFactory.getLogger(WorkflowActionJob.class);
 		listAppender = new ListAppender<>();
+		ReflectionTestUtils.setField(workflowActionJob, "environment", new StandardEnvironment());
 		ReflectionTestUtils.setField(workflowActionJob, "clusterManagerUrl", "/dummyPath");
 	}
 

--- a/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowInternalActionVerticleTest.java
+++ b/registration-processor/workflow-engine/registration-processor-workflow-manager-service/src/test/java/io/mosip/registration/processor/workflowmanager/verticle/WorkflowInternalActionVerticleTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -186,7 +187,8 @@ public class WorkflowInternalActionVerticleTest {
 	@Test
 	public void testDeployVerticle() {
 
-		ReflectionTestUtils.setField(workflowInternalActionVerticle, "workerPoolSize", 10);
+		ReflectionTestUtils.setField(workflowInternalActionVerticle, "environment", new StandardEnvironment());
+		ReflectionTestUtils.setField(workflowInternalActionVerticle, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(workflowInternalActionVerticle, "clusterManagerUrl", "/dummyPath");
 		ReflectionTestUtils.setField(workflowInternalActionVerticle, "defaultMaxAllowedIteration", 5);
 		workflowInternalActionVerticle.deployVerticle();


### PR DESCRIPTION
## Summary

This PR introduces two performance/tuning improvements for the registration processor:

1. **Fewer packetmanager calls in the packet validator stage** – MetaInfo is fetched once per packet and passed through validation and related logic instead of being requested multiple times.
2. **Per-stage worker pool size override** – Each stage can override the global `worker.pool.size` via a stage-specific property (e.g. `mosip.regproc.packet.validator.worker.pool.size`).

---

## 1. Reducing packetmanager calls (VALIDATE_PACKET stage)

### Problem

The packet validator stage was making **many sequential calls** to the packetmanager service per packet (e.g. multiple `getMetaInfo`, `getField`, `getDocument`, `getBiometrics`, `getFields`, `getAudits`). In particular, `getMetaInfo()` was invoked repeatedly from:

- `setPacketCreatedDateTime()`
- `compositePacketValidator.validate()`
- `reverseDataSync()`

That led to high average processing time per packet (~47s in some runs) and limited throughput despite sufficient Kafka partitions and worker threads.

### Solution

- **Single MetaInfo fetch per packet**  
  In `PacketValidateProcessor.process()`, MetaInfo is fetched **once** at the start via `packetManagerService.getMetaInfo(registrationId)` and stored in a `Map<String, String>`.

- **Pass MetaInfo through the flow**  
  - The existing 3-argument `validate(...)` on `PacketValidator` is kept and delegates to a new 4-argument `validate(..., Map<String, String> metaInfo)` with `metaInfo = null` for backward compatibility.
  - `PacketValidatorImpl` and `CompositePacketValidator` implement the 4-argument `validate` and use the supplied `metaInfo` when present.
  - `setPacketCreatedDateTime()` and `reverseDataSync()` accept an optional pre-fetched `metaInfo` map and only call `packetManagerService.getMetaInfo()` when it is null.

- **Result**  
  Redundant `getMetaInfo` calls in the validator flow are removed, reducing load on the packetmanager and improving per-packet processing time for the VALIDATE_PACKET stage.

### Files touched (high level)

- `PacketValidator` (interface): new 4-arg `validate(..., metaInfo)`; 3-arg default implementation.
- `PacketValidatorImpl`, `CompositePacketValidator`: implement 4-arg `validate` and use passed `metaInfo`.
- `PacketValidateProcessor`: single `getMetaInfo` at start; pass `metaInfo` into `setPacketCreatedDateTime`, `compositePacketValidator.validate`, and `reverseDataSync`.
- Unit tests: `CompositePacketValidatorTest`, `CompositeValidatorTest`, `PacketValidateProcessorTest` updated for the new `validate` signature and behaviour.

---

## 2. Per-stage worker pool size override

### Problem

Worker pool size was controlled only by the global `worker.pool.size`. There was no way to give a specific stage (e.g. packet validator or quality classifier) a different pool size for tuning.

### Solution

- **Central resolution in `MosipVerticleAPIManager`**  
  - A single default is injected: `@Value("${worker.pool.size}") private Integer defaultWorkerPoolSize`.
  - A protected method `getWorkerPoolSize()`:
    - Looks up a stage-specific override: `{getPropertyPrefix()}worker.pool.size` (e.g. `mosip.regproc.packet.validator.worker.pool.size`).
    - If the override is set and valid (numeric), returns that value.
    - If the override is missing, empty, or invalid, returns `defaultWorkerPoolSize` (or 1 if default is null).

- **Stages use `getWorkerPoolSize()`**  
  All stages/verticles that previously declared their own `@Value("${worker.pool.size}") private Integer workerPoolSize` now:
  - Rely on the base class `defaultWorkerPoolSize` and `getWorkerPoolSize()`.
  - Call `getWorkerPoolSize()` where they need the pool size (e.g. `getEventBus(this, clusterManagerUrl, getWorkerPoolSize())`, and in `QualityClassifierStage` for the ForkJoinPool size).

- **Backward compatibility**  
  If no stage-specific property is set, behaviour is unchanged: every stage uses the global `worker.pool.size`.

### Example configuration

```properties
# Global default (unchanged)
worker.pool.size=20

# Override only for packet validator stage
mosip.regproc.packet.validator.worker.pool.size=30
```

### Files touched (high level)

- `MosipVerticleAPIManager`: added `defaultWorkerPoolSize` and `getWorkerPoolSize()`; removed per-stage `workerPoolSize` usage from base.
- All affected stages/verticles (e.g. WorkflowInternalActionVerticle, WorkflowActionApi, QualityClassifierStage, MessageSenderStage, CredentialRequestorStage, VerificationStage, UinGeneratorStage, ManualAdjudicationStage, FinalizationStage, DemoDedupeStage, BiometricExtractionStage, BiometricAuthenticationStage, BioDedupeStage, AbisMiddleWareStage, AbisHandlerStage, plus any others already using `getWorkerPoolSize()`): removed local `workerPoolSize` and use `getWorkerPoolSize()`.
- Stage/verticle tests: `ReflectionTestUtils.setField(..., "workerPoolSize", ...)` updated to `"defaultWorkerPoolSize"` where applicable.
- New test: `MosipVerticleAPIManagerWorkerPoolSizeTest` for default, override, empty, invalid, and null-default behaviour.

---

## Testing

- **Packet validator / metaInfo**  
  Unit tests updated and passing for `PacketValidateProcessor`, `CompositePacketValidator`, and related validators.

- **Worker pool size**  
  - `MosipVerticleAPIManagerWorkerPoolSizeTest` added and passing.
  - Existing stage tests updated to set `defaultWorkerPoolSize`; stages compile and tests run successfully (e.g. core + packet-validator-stage build).

---

## Impact

- **Performance**  
  Fewer packetmanager round-trips per packet in the validator stage, enabling higher throughput and lower latency for VALIDATE_PACKET when packetmanager or network is a bottleneck.

- **Operational flexibility**  
  Per-stage worker pool size allows tuning heavy stages (e.g. packet validator, quality classifier) without changing the global pool size.
