### PR TITLE
[MOSIP-44824] Move code fix for processing packets created with older schema from Java 11 to Java 21 in develop branch

### DIFF
--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
@@ -253,16 +253,17 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 			} else {
 				IdResponseDTO idResponseDTO = new IdResponseDTO();
 				String schemaVersion = packetManagerService.getFieldByMappingJsonKey(registrationId, MappingJsonConstants.IDSCHEMA_VERSION, registrationStatusDto.getRegistrationType(), ProviderStageName.UIN_GENERATOR);
+				List<String> defaultFields = idSchemaUtil.getDefaultFields(Double.valueOf(schemaVersion));
 
 				Map<String, String> fieldMap = packetManagerService.getFields(registrationId,
-						idSchemaUtil.getDefaultFields(Double.valueOf(schemaVersion)), registrationStatusDto.getRegistrationType(), ProviderStageName.UIN_GENERATOR);
+						defaultFields, registrationStatusDto.getRegistrationType(), ProviderStageName.UIN_GENERATOR);
 				String uinField = utility.getUIn(registrationId, registrationStatusDto.getRegistrationType(), ProviderStageName.UIN_GENERATOR);
 				JSONObject demographicIdentity = new JSONObject();
 				demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, convertIdschemaToDouble ? Double.valueOf(schemaVersion) : schemaVersion);
 
 				loadDemographicIdentity(fieldMap, demographicIdentity);
 
-				updatePacketCreatedOnInDemographicIdentity(registrationId, registrationStatusDto, demographicIdentity, object);
+				updatePacketCreatedOnInDemographicIdentity(registrationId, registrationStatusDto, demographicIdentity, object, defaultFields);
 
 				if (StringUtils.isEmpty(uinField) || uinField.equalsIgnoreCase("null") ) {
 
@@ -1167,7 +1168,21 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 
 	private void updatePacketCreatedOnInDemographicIdentity(String registrationId,
 															InternalRegistrationStatusDto registrationStatusDto,
-															Map<String, Object> demographicIdentity, MessageDTO object) throws IOException, PacketManagerException, ApisResourceAccessException, JsonProcessingException {
+															Map<String, Object> demographicIdentity, MessageDTO object, List<String> defaultFields) throws IOException, PacketManagerException, ApisResourceAccessException, JsonProcessingException {
+
+		// Skip processing if 'packetCreatedOn' is not part of IdSchema
+		if (!defaultFields.contains(MappingJsonConstants.PACKET_CREATED_ON)) {
+			Object schemaVersion = demographicIdentity.get(MappingJsonConstants.IDSCHEMA_VERSION);
+			regProcLogger.info(
+					LoggerFileConstant.SESSIONID.toString(),
+					LoggerFileConstant.REGISTRATIONID.toString(),
+					registrationId,
+					"packetCreatedOn not found in packet idSchemaVersion " + schemaVersion +
+							". Skipping addition to identity attributes."
+			);
+			return;
+		}
+
 		// update packetCreatedOn only for NEW and UPDATE registrations
 		if (!RegistrationType.NEW.toString().equalsIgnoreCase(object.getReg_type()) &&
 				!RegistrationType.UPDATE.toString().equalsIgnoreCase(object.getReg_type())) {

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
@@ -1171,7 +1171,7 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 															Map<String, Object> demographicIdentity, MessageDTO object, List<String> defaultFields) throws IOException, PacketManagerException, ApisResourceAccessException, JsonProcessingException {
 
 		// Skip processing if 'packetCreatedOn' is not part of IdSchema
-		if (!defaultFields.contains(MappingJsonConstants.PACKET_CREATED_ON)) {
+		if (defaultFields == null || !defaultFields.contains(MappingJsonConstants.PACKET_CREATED_ON)) {
 			Object schemaVersion = demographicIdentity.get(MappingJsonConstants.IDSCHEMA_VERSION);
 			regProcLogger.info(
 					LoggerFileConstant.SESSIONID.toString(),

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
@@ -2992,7 +2992,7 @@ public class UinGeneratorStageTest {
 	}
 
 	@Test
-	public void testPacketCreatedOn_NotPresentInSchema_ShouldSkipUpdate() {
+	public void testPacketCreatedOn_NotPresentInSchema_ShouldSkipUpdate() throws IOException, PacketManagerException, ApisResourceAccessException, JsonProcessingException {
 
 		String rid = "10031100110005020190313110030";
 
@@ -3005,6 +3005,10 @@ public class UinGeneratorStageTest {
 
 		// Simulate old schema where packetCreatedOn is NOT present
 		List<String> defaultFields = Arrays.asList("name", "email", "dateOfBirth");
+		// Keep downstream prerequisites valid so this test proves schema-based skip specifically
+		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn("packetCreatedOn");
+		when(utility.retrieveCreatedDateFromPacket(
+				rid, "NEW", ProviderStageName.UIN_GENERATOR)).thenReturn("2025-03-08T12:00:00Z");
 
 		JSONObject demographicIdentity = new JSONObject();
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/test/java/io/mosip/registration/processor/stages/uigenerator/UinGeneratorStageTest.java
@@ -2669,6 +2669,9 @@ public class UinGeneratorStageTest {
 		InternalRegistrationStatusDto internalRegistrationStatusDto = new InternalRegistrationStatusDto();
 		internalRegistrationStatusDto.setRegistrationType("NEW");
 
+		// important: packetCreatedOn must exist so method doesn't exit early
+		List<String> defaultFields = Arrays.asList("UIN", "name", "email", "packetCreatedOn");
+
 		when(utility.getUIn(any(),any(),any(ProviderStageName.class))).thenReturn("123456");
 		when(packetManagerService.getFields(any(), any(), any(), any())).thenReturn(fieldMap);
 		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn(null);
@@ -2677,7 +2680,7 @@ public class UinGeneratorStageTest {
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
 
 		ReflectionTestUtils.invokeMethod(uinGeneratorStage, "updatePacketCreatedOnInDemographicIdentity",
-				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO);
+				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO, defaultFields);
 		assertNull(demographicIdentity.get("packetCreatedOn"));
 
 	}
@@ -2696,13 +2699,16 @@ public class UinGeneratorStageTest {
 		metaInfo.put(MappingJsonConstants.PACKET_CREATED_ON, "2025-3-08T12:00:00Z");
 
 		when(packetManagerService.getMetaInfo(rid, "NEW", ProviderStageName.UIN_GENERATOR)).thenReturn(metaInfo);
+
+		// schema fields must contain packetCreatedOn
+		List<String> defaultFields = Arrays.asList("fullName", "dateOfBirth", "packetCreatedOn");
 		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn("packetCreatedOn");
 
 		org.json.simple.JSONObject demographicIdentity = new org.json.simple.JSONObject();
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
 
 		ReflectionTestUtils.invokeMethod(uinGeneratorStage, "updatePacketCreatedOnInDemographicIdentity",
-				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO);
+				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO, defaultFields);
 
 		assertEquals("2019-01-17T06:29:01.940Z", demographicIdentity.get("packetCreatedOn"));
 	}
@@ -2721,13 +2727,16 @@ public class UinGeneratorStageTest {
 		metaInfo.put(MappingJsonConstants.PACKET_CREATED_ON, "2025-10-13T12:00:00Z");
 
 		when(packetManagerService.getMetaInfo(rid, "NEW", ProviderStageName.UIN_GENERATOR)).thenReturn(metaInfo);
+
+		// schema fields must include packetCreatedOn
+		List<String> defaultFields = Arrays.asList("name", "email", "packetCreatedOn");
 		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn("packetCreatedOn");
 
 		org.json.simple.JSONObject demographicIdentity = new org.json.simple.JSONObject();
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
 
 		ReflectionTestUtils.invokeMethod(uinGeneratorStage, "updatePacketCreatedOnInDemographicIdentity",
-				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO);
+				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO, defaultFields);
 
 		assertEquals("2019-01-17T06:29:01.940Z", demographicIdentity.get("packetCreatedOn"));
 	}
@@ -2742,6 +2751,8 @@ public class UinGeneratorStageTest {
 		InternalRegistrationStatusDto internalRegistrationStatusDto = new InternalRegistrationStatusDto();
 		internalRegistrationStatusDto.setRegistrationType("NEW");
 
+		// schema fields must contain packetCreatedOn
+		List<String> defaultFields = Arrays.asList("name", "email", "packetCreatedOn");
 		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn("packetCreatedOn");
 		when(utility.retrieveCreatedDateFromPacket(anyString(), anyString(), any())).thenReturn(null);
 
@@ -2749,7 +2760,7 @@ public class UinGeneratorStageTest {
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
 
 		ReflectionTestUtils.invokeMethod(uinGeneratorStage, "updatePacketCreatedOnInDemographicIdentity",
-				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO);
+				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO, defaultFields);
 
 		assertNull(demographicIdentity.get("packetCreatedOn"));
 	}
@@ -2764,6 +2775,8 @@ public class UinGeneratorStageTest {
 		InternalRegistrationStatusDto internalRegistrationStatusDto = new InternalRegistrationStatusDto();
 		internalRegistrationStatusDto.setRegistrationType("LOST");
 
+		// schema must contain packetCreatedOn
+		List<String> defaultFields = Arrays.asList("name", "email", "packetCreatedOn");
 		when(utility.getMappedFieldName(MappingJsonConstants.PACKET_CREATED_ON)).thenReturn("packetCreatedOn");
 		when(utility.retrieveCreatedDateFromPacket(anyString(), anyString(), any())).thenReturn(null);
 
@@ -2771,7 +2784,7 @@ public class UinGeneratorStageTest {
 		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
 
 		ReflectionTestUtils.invokeMethod(uinGeneratorStage, "updatePacketCreatedOnInDemographicIdentity",
-				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO);
+				rid, internalRegistrationStatusDto, demographicIdentity, messageDTO, defaultFields);
 
 		assertNull(demographicIdentity.get("packetCreatedOn"));
 	}
@@ -2976,6 +2989,38 @@ public class UinGeneratorStageTest {
 		MessageDTO result = uinGeneratorStage.process(messageDTO);
 		assertTrue(result.getIsValid());
 		assertFalse(result.getInternalError());
+	}
+
+	@Test
+	public void testPacketCreatedOn_NotPresentInSchema_ShouldSkipUpdate() {
+
+		String rid = "10031100110005020190313110030";
+
+		MessageDTO messageDTO = new MessageDTO();
+		messageDTO.setRid(rid);
+		messageDTO.setReg_type("NEW");
+
+		InternalRegistrationStatusDto internalRegistrationStatusDto = new InternalRegistrationStatusDto();
+		internalRegistrationStatusDto.setRegistrationType("NEW");
+
+		// Simulate old schema where packetCreatedOn is NOT present
+		List<String> defaultFields = Arrays.asList("name", "email", "dateOfBirth");
+
+		JSONObject demographicIdentity = new JSONObject();
+		demographicIdentity.put(MappingJsonConstants.IDSCHEMA_VERSION, 1.0);
+
+		ReflectionTestUtils.invokeMethod(
+				uinGeneratorStage,
+				"updatePacketCreatedOnInDemographicIdentity",
+				rid,
+				internalRegistrationStatusDto,
+				demographicIdentity,
+				messageDTO,
+				defaultFields
+		);
+
+		// packetCreatedOn should not be added
+		assertNull(demographicIdentity.get("packetCreatedOn"));
 	}
 
 }


### PR DESCRIPTION
[MOSIP-44824] Move code fix for processing packets created with older schema from Java 11 to Java 21 in develop branch

[MOSIP-44824]: https://mosip.atlassian.net/browse/MOSIP-44824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip inserting packet creation timestamp when the current schema does not define that field; operation is logged and no timestamp is added.

* **Chores**
  * Reduced repeated schema field lookups by computing default schema fields once and reusing them during processing.

* **Tests**
  * Added a unit test covering the case where the schema lacks the packet creation field to verify no insertion occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->