### PR TITLE
Fix Kafka commit ordering after producer writes

### DIFF
--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBus.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBus.java
@@ -178,7 +178,7 @@ public class KafkaMosipEventBus implements MosipEventBus {
 		this.eventTracingHandler.writeHeaderOnKafkaProduce(producerRecord);
 		Map<String, String> mdc = MDC.getCopyOfContextMap();
   		kafkaProducer.write(producerRecord, handler -> {
-			MDC.setContextMap(mdc);
+			setMDCContextMap(mdc);
   			if(handler.failed())
 				logger.error("Failed kafkaProducer.write {} {} ", handler.result(), handler.cause());
   			else
@@ -317,6 +317,29 @@ public class KafkaMosipEventBus implements MosipEventBus {
 		return promise.future();
 	}
 
+	private void completeProcessedRecord(KafkaConsumerRecord<String, String> record, boolean commitRecord,
+			Promise<Void> promise) {
+		if(commitRecord)
+			commitOffset(record.topic(), record.partition(),
+				record.offset(), promise);
+		else
+			promise.complete();
+	}
+
+	private void failPromise(Promise<Void> promise, Throwable cause, String failureMessage) {
+		if(cause != null)
+			promise.fail(cause);
+		else
+			promise.fail(failureMessage);
+	}
+
+	private void setMDCContextMap(Map<String, String> mdc) {
+		if(mdc != null)
+			MDC.setContextMap(mdc);
+		else
+			MDC.clear();
+	}
+
 	Future<Void> processRecord(MessageBusAddress toAddress,
 			EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> eventHandler,
 		KafkaConsumerRecord<String, String> record, boolean commitRecord) {
@@ -330,14 +353,12 @@ public class KafkaMosipEventBus implements MosipEventBus {
 		eventHandler.handle(eventDTO, res -> {
 			if (!res.succeeded() && res.cause() instanceof MessageExpiredException) {
 				logger.warn("Event handling failed {}", res.cause().getMessage());
-				if(commitRecord)
-					commitOffset(record.topic(), record.partition(), 
-						record.offset(), promise);
-				else					
-					promise.complete();
+				completeProcessedRecord(record, commitRecord, promise);
+				this.eventTracingHandler.closeSpan(span);
 			} else if(!res.succeeded()) {
 				logger.error("Event handling failed {}", res.cause());
-				promise.fail(res.cause());
+				failPromise(promise, res.cause(), "Event handling failed");
+				this.eventTracingHandler.closeSpan(span);
 			} else {
 				if(toAddress != null) {
 					MessageDTO messageDTO = res.result();
@@ -349,21 +370,22 @@ public class KafkaMosipEventBus implements MosipEventBus {
 								getKafkaKey(messageDTO, messageBusToAddress), jsonObject.toString());
 					this.eventTracingHandler.writeHeaderOnKafkaProduce(producerRecord, span);
 					kafkaProducer.write(producerRecord, handler -> {
-						MDC.setContextMap(mdc);
-						if(handler.failed())
+						setMDCContextMap(mdc);
+						if(handler.failed()) {
 							logger.error("Failed kafkaProducer.write {} ", handler.result(), handler.cause());
-						else
+							failPromise(promise, handler.cause(), "Failed kafkaProducer.write");
+						} else {
 							logger.info("Success kafkaProducer.write {} ", handler.result());
+							completeProcessedRecord(record, commitRecord, promise);
+						}
 						MDC.clear();
+						this.eventTracingHandler.closeSpan(span);
 					});
+				} else {
+					completeProcessedRecord(record, commitRecord, promise);
+					this.eventTracingHandler.closeSpan(span);
 				}
-				if(commitRecord)
-					commitOffset(record.topic(), record.partition(), 
-						record.offset(), promise);
-				else					
-					promise.complete();
 			}
-			this.eventTracingHandler.closeSpan(span);
 		});
 		return promise.future();
 	}

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBus.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBus.java
@@ -333,6 +333,14 @@ public class KafkaMosipEventBus implements MosipEventBus {
 			promise.fail(failureMessage);
 	}
 
+	private void resumeRecordPartition(KafkaConsumerRecord<String, String> record) {
+		Promise<Void> resumePromise = Promise.promise();
+		resumePartition(new TopicPartition(record.topic(), record.partition()), resumePromise);
+		resumePromise.future().onFailure(cause -> logger.error(
+			"Partition resume failed for topic: {} partition: {}",
+			record.topic(), record.partition(), cause));
+	}
+
 	private void setMDCContextMap(Map<String, String> mdc) {
 		if(mdc != null)
 			MDC.setContextMap(mdc);
@@ -373,6 +381,7 @@ public class KafkaMosipEventBus implements MosipEventBus {
 						setMDCContextMap(mdc);
 						if(handler.failed()) {
 							logger.error("Failed kafkaProducer.write {} ", handler.result(), handler.cause());
+							resumeRecordPartition(record);
 							failPromise(promise, handler.cause(), "Failed kafkaProducer.write");
 						} else {
 							logger.info("Success kafkaProducer.write {} ", handler.result());

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBusTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBusTest.java
@@ -123,6 +123,15 @@ public class KafkaMosipEventBusTest {
 		}).when(kafkaConsumer).commit(anyMap(), any());
 	}
 
+	private void mockResumeResult(boolean succeeded) {
+		AsyncResult<Void> voidAsyncResult = Mockito.mock(AsyncResult.class);
+		Mockito.when(voidAsyncResult.succeeded()).thenReturn(succeeded);
+		doAnswer((Answer<AsyncResult<Void>>) arguments -> {
+			((Handler<AsyncResult<Void>>) arguments.getArgument(1)).handle(voidAsyncResult);
+			return null;
+		}).when(kafkaConsumer).resume(any(io.vertx.kafka.client.common.TopicPartition.class), any());
+	}
+
 	private EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> prepareSuccessfulEventHandler() {
 		EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> eventHandler =
 			Mockito.mock(EventHandler.class);
@@ -361,6 +370,7 @@ public class KafkaMosipEventBusTest {
 
 	@Test
 	public void testProcessRecordCommitsAfterProducerWriteSuccess(TestContext testContext) {
+		Async async = testContext.async();
 		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
 			"single", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
 		mockCommitResult(true);
@@ -368,42 +378,62 @@ public class KafkaMosipEventBusTest {
 		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
 			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), true);
 
-		assertTrue(result.succeeded());
-		InOrder inOrder = Mockito.inOrder(kafkaProducer, kafkaConsumer);
-		inOrder.verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
-		inOrder.verify(kafkaConsumer, times(1)).commit(anyMap(), any());
+		result.onComplete(handler -> {
+			assertTrue(handler.succeeded());
+			InOrder inOrder = Mockito.inOrder(kafkaProducer, kafkaConsumer);
+			inOrder.verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+			inOrder.verify(kafkaConsumer, times(1)).commit(anyMap(), any());
+			async.complete();
+		});
+		async.await();
 	}
 
 	@Test
 	public void testProcessRecordFailsAndDoesNotCommitWhenProducerWriteFails(TestContext testContext) {
+		Async async = testContext.async();
 		RuntimeException producerException = new RuntimeException("producer write failed");
 		mockKafkaProducerWriteResult(true, producerException);
+		mockResumeResult(true);
 		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
 			"single", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
 
 		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
 			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), true);
 
-		assertTrue(result.failed());
-		assertEquals(producerException, result.cause());
-		verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
-		verify(kafkaConsumer, times(0)).commit(anyMap(), any());
+		result.onComplete(handler -> {
+			assertTrue(handler.failed());
+			assertEquals(producerException, handler.cause());
+			verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+			verify(kafkaConsumer, times(0)).commit(anyMap(), any());
+			verify(kafkaConsumer, times(1)).resume(
+				any(io.vertx.kafka.client.common.TopicPartition.class), any());
+			async.complete();
+		});
+		async.await();
 	}
 
 	@Test
 	public void testProcessRecordFailsBatchFutureWhenProducerWriteFails(TestContext testContext) {
+		Async async = testContext.async();
 		RuntimeException producerException = new RuntimeException("producer write failed");
 		mockKafkaProducerWriteResult(true, producerException);
+		mockResumeResult(true);
 		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
 			"batch", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
 
 		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
 			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), false);
 
-		assertTrue(result.failed());
-		assertEquals(producerException, result.cause());
-		verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
-		verify(kafkaConsumer, times(0)).commit(anyMap(), any());
+		result.onComplete(handler -> {
+			assertTrue(handler.failed());
+			assertEquals(producerException, handler.cause());
+			verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+			verify(kafkaConsumer, times(0)).commit(anyMap(), any());
+			verify(kafkaConsumer, times(1)).resume(
+				any(io.vertx.kafka.client.common.TopicPartition.class), any());
+			async.complete();
+		});
+		async.await();
 	}
 
 	@Test

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBusTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/core/eventbus/KafkaMosipEventBusTest.java
@@ -47,6 +47,7 @@ import io.mosip.registration.processor.core.exception.MessageExpiredException;
 import io.mosip.registration.processor.core.spi.eventbus.EventHandler;
 import io.mosip.registration.processor.core.tracing.EventTracingHandler;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -55,6 +56,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordsImpl;
@@ -97,6 +99,56 @@ public class KafkaMosipEventBusTest {
 			.thenReturn(kafkaProducer);
 
 		eventTracingHandler = new EventTracingHandler(tracing, "kafka");
+		mockKafkaProducerWriteResult(false, null);
+	}
+
+
+	private void mockKafkaProducerWriteResult(boolean failed, Throwable cause) {
+		AsyncResult producerAsyncResult = Mockito.mock(AsyncResult.class);
+		Mockito.when(producerAsyncResult.failed()).thenReturn(failed);
+		Mockito.when(producerAsyncResult.succeeded()).thenReturn(!failed);
+		Mockito.when(producerAsyncResult.cause()).thenReturn(cause);
+		doAnswer((Answer<KafkaProducer<String, String>>) arguments -> {
+			((Handler<AsyncResult>) arguments.getArgument(1)).handle(producerAsyncResult);
+			return kafkaProducer;
+		}).when(kafkaProducer).write(any(KafkaProducerRecord.class), any(Handler.class));
+	}
+
+	private void mockCommitResult(boolean succeeded) {
+		AsyncResult<Void> voidAsyncResult = Mockito.mock(AsyncResult.class);
+		Mockito.when(voidAsyncResult.succeeded()).thenReturn(succeeded);
+		doAnswer((Answer<AsyncResult<Void>>) arguments -> {
+			((Handler<AsyncResult<Void>>) arguments.getArgument(1)).handle(voidAsyncResult);
+			return null;
+		}).when(kafkaConsumer).commit(anyMap(), any());
+	}
+
+	private EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> prepareSuccessfulEventHandler() {
+		EventHandler<EventDTO, Handler<AsyncResult<MessageDTO>>> eventHandler =
+			Mockito.mock(EventHandler.class);
+		doAnswer((Answer<AsyncResult<MessageDTO>>) arguments -> {
+			AsyncResult<MessageDTO> asyncResultForMessageDTO = Mockito.mock(AsyncResult.class);
+			Mockito.when(asyncResultForMessageDTO.succeeded()).thenReturn(true);
+			MessageDTO messageDTO = new MessageDTO();
+			messageDTO.setRid("1001");
+			messageDTO.setReg_type(RegistrationType.NEW.name());
+			Mockito.when(asyncResultForMessageDTO.result()).thenReturn(messageDTO);
+			((Handler<AsyncResult<MessageDTO>>) arguments.getArgument(1))
+				.handle(asyncResultForMessageDTO);
+			return null;
+		}).when(eventHandler).handle(any(), any());
+		return eventHandler;
+	}
+
+	private KafkaConsumerRecord<String, String> prepareKafkaConsumerRecord() {
+		KafkaConsumerRecord<String, String> record = Mockito.mock(KafkaConsumerRecord.class);
+		Mockito.when(record.headers()).thenReturn(new ArrayList<>());
+		Mockito.when(record.key()).thenReturn("1001");
+		Mockito.when(record.value()).thenReturn("{\"rid\":\"1001\", \"reg_type\": \"NEW\" }");
+		Mockito.when(record.topic()).thenReturn(MessageBusAddress.PACKET_VALIDATOR_BUS_IN.getAddress());
+		Mockito.when(record.partition()).thenReturn(0);
+		Mockito.when(record.offset()).thenReturn(10L);
+		return record;
 	}
 
 	@After
@@ -304,6 +356,54 @@ public class KafkaMosipEventBusTest {
 				values.get(i).entrySet().iterator().next().getValue().getOffset() == i+1);
 		}
 		verify(kafkaProducer, times(testDataCount)).write(any(), any());
+	}
+
+
+	@Test
+	public void testProcessRecordCommitsAfterProducerWriteSuccess(TestContext testContext) {
+		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
+			"single", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
+		mockCommitResult(true);
+
+		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
+			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), true);
+
+		assertTrue(result.succeeded());
+		InOrder inOrder = Mockito.inOrder(kafkaProducer, kafkaConsumer);
+		inOrder.verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+		inOrder.verify(kafkaConsumer, times(1)).commit(anyMap(), any());
+	}
+
+	@Test
+	public void testProcessRecordFailsAndDoesNotCommitWhenProducerWriteFails(TestContext testContext) {
+		RuntimeException producerException = new RuntimeException("producer write failed");
+		mockKafkaProducerWriteResult(true, producerException);
+		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
+			"single", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
+
+		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
+			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), true);
+
+		assertTrue(result.failed());
+		assertEquals(producerException, result.cause());
+		verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+		verify(kafkaConsumer, times(0)).commit(anyMap(), any());
+	}
+
+	@Test
+	public void testProcessRecordFailsBatchFutureWhenProducerWriteFails(TestContext testContext) {
+		RuntimeException producerException = new RuntimeException("producer write failed");
+		mockKafkaProducerWriteResult(true, producerException);
+		kafkaMosipEventBus = new KafkaMosipEventBus(vertx, "localhost:9091", "group_1",
+			"batch", "100", "30000", 60000, eventTracingHandler, caffeineCacheManager);
+
+		Future<Void> result = kafkaMosipEventBus.processRecord(MessageBusAddress.PACKET_UPLOADER_OUT,
+			prepareSuccessfulEventHandler(), prepareKafkaConsumerRecord(), false);
+
+		assertTrue(result.failed());
+		assertEquals(producerException, result.cause());
+		verify(kafkaProducer, times(1)).write(any(KafkaProducerRecord.class), any(Handler.class));
+		verify(kafkaConsumer, times(0)).commit(anyMap(), any());
 	}
 
 	@Test


### PR DESCRIPTION
## Description
- Delay Kafka consumer offset completion until downstream producer writes succeed.
- Propagate producer write failures through the processing future so single and batch commit paths do not acknowledge records that were not written to the next topic.
- Add focused KafkaMosipEventBus tests for producer-success commit ordering and producer-failure behavior.

Fixes #2305

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH mvn -pl registration-processor-core -Dtest=KafkaMosipEventBusTest -DfailIfNoTests=false -Dgpg.skip=true -Dmaven.javadoc.skip=true test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event processing and message-handling flow, including safer context propagation and more precise tracing/span lifecycle to ensure accurate commit/rollback behavior.

* **Tests**
  * Added unit tests covering producer success and failure paths and commit/resume behavior to validate processing across single and batch modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->