### PR TITLE
MOSIP-44198: Removed the race condition fix for abisMiddleWareStage

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -344,14 +344,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 				validateNullCheck(abisQueue, ABIS_QUEUE_NOT_FOUND);
 				byte[] reqBytearray = abisIdentifyRequest.getReqText();
 
-				// Mark SENT in DB before sending to queue to prevent race condition where
-				// ABIS responds before the status update, causing the response to be dropped.
-				updateAbisRequest(true, abisIdentifyRequest, internalRegDto);
 				boolean isAddedToQueue = sendToQueue(abisQueue.get(0).getMosipQueue(), new String(reqBytearray),
 						abisQueue.get(0).getInboundQueueName(), abisQueue.get(0).getInboundMessageTTL());
-				if (!isAddedToQueue) {
-					updateAbisRequest(false, abisIdentifyRequest, internalRegDto);
-				}
+				updateAbisRequest(isAddedToQueue, abisIdentifyRequest, internalRegDto);
+
 			}
 
 		}
@@ -364,13 +360,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 
 			byte[] reqBytearray = abisInprogressRequest.getReqText();
 
-			// Mark SENT in DB before sending to queue to prevent race condition.
-			updateAbisRequest(true, abisInprogressRequest, internalRegDto);
 			boolean isAddedToQueue = sendToQueue(abisQueue.get(0).getMosipQueue(), new String(reqBytearray),
 					abisQueue.get(0).getInboundQueueName(), abisQueue.get(0).getInboundMessageTTL());
-			if (!isAddedToQueue) {
-				updateAbisRequest(false, abisInprogressRequest, internalRegDto);
-			}
+			updateAbisRequest(isAddedToQueue, abisInprogressRequest, internalRegDto);
+
 		}
 		// send all identify requests for already processed insert requests
 		for (AbisRequestDto abisAlreadyProcessedInsertRequest : abisAlreadyprocessedInsertRequestList) {
@@ -382,13 +375,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 					.filter(dto -> dto.getAbisAppCode().equals(abisAlreadyProcessedInsertRequest.getAbisAppCode()))
 					.collect(Collectors.toList());
 			byte[] reqBytearray = identifyRequest.get(0).getReqText();
-			// Mark SENT in DB before sending to queue to prevent race condition.
-			updateAbisRequest(true, identifyRequest.get(0), internalRegDto);
 			boolean isAddedToQueue = sendToQueue(abisQueue.get(0).getMosipQueue(), new String(reqBytearray),
 					abisQueue.get(0).getInboundQueueName(), abisQueue.get(0).getInboundMessageTTL());
-			if (!isAddedToQueue) {
-				updateAbisRequest(false, identifyRequest.get(0), internalRegDto);
-			}
+			updateAbisRequest(isAddedToQueue, identifyRequest.get(0), internalRegDto);
+
 		}
 	}
 
@@ -462,14 +452,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 							.collect(Collectors.toList());
 					validateNullCheck(abisIdentifyRequest, "IDENTIFY_REQUESTS_NOT_FOUND");
 					AbisRequestDto abisIdentifyRequestDto = abisIdentifyRequest.get(0);
-					// Mark SENT in DB before sending to queue to prevent race condition where
-					// ABIS responds before the status update, causing the identify response to be dropped.
-					updateAbisRequest(true, abisIdentifyRequestDto, internalRegStatusDto);
 					boolean isAddedToQueue = sendToQueue(queue, new String(abisIdentifyRequestDto.getReqText()),
 							abisInBoundAddress, inboundMessageTTL);
-					if (!isAddedToQueue) {
-						updateAbisRequest(false, abisIdentifyRequestDto, internalRegStatusDto);
-					}
+					updateAbisRequest(isAddedToQueue, abisIdentifyRequestDto, internalRegStatusDto);
+
 				} else {
 					internalRegStatusDto
 							.setLatestTransactionStatusCode(RegistrationTransactionStatusCode.REPROCESS.toString());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ABIS request status tracking reliability. The system now updates request status only after successfully queuing IDENTIFY requests, rather than pre-marking status and potentially reverting it on failure. This ensures more consistent and accurate status management throughout the registration processing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/registration/pull/2348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->