### PR TITLE
Resolves #2366 Adding support for scheduled delay in ABIS middleware while sending the message to ABIS to simulate the real time behavior

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -428,6 +428,11 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 					"AbisMiddlewareStage::consumerListener()::response from abis for requestId ::" + requestId);
 
 			AbisRequestDto abisCommonRequestDto = packetInfoManager.getAbisRequestByRequestId(requestId);
+			regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
+					"AbisMiddlewareStage::consumerListener()::Fetched ABIS request metadata for requestId="
+							+ requestId + ", requestType=" + abisCommonRequestDto.getRequestType() + ", statusCode="
+							+ abisCommonRequestDto.getStatusCode() + ", batchId=" + batchId + ", registrationId="
+							+ registrationId);
 			// check for insert response,if success send corresponding identify request to
 			// queue
 			if (abisCommonRequestDto.getRequestType().equals(AbisStatusCode.INSERT.toString())) {
@@ -473,10 +478,12 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 				}
 
 				} else {
-					regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
-							"",
-							"AbisMiddlewareStage::consumerListener()::Duplicate Insert Response received from abis for same request id ::"
-									+ requestId + " response " + inserOrIdentifyResponse);
+					regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
+							registrationId,
+							"AbisMiddlewareStage::consumerListener()::Skipping INSERT response because request status is not SENT. requestId="
+									+ requestId + ", currentStatus=" + abisCommonRequestDto.getStatusCode()
+									+ ", expectedStatus=" + AbisStatusCode.SENT.toString() + ", response="
+									+ inserOrIdentifyResponse);
 					isTransactionSuccessful = false;
 					description.setMessage(PlatformErrorMessages.DUPLICATE_INSERT_RESPONSE.getMessage() + requestId);
 					description.setCode(PlatformErrorMessages.DUPLICATE_INSERT_RESPONSE.getCode());
@@ -524,15 +531,25 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 
 					}
 				} else {
-					regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
-							"",
-							"AbisMiddlewareStage::consumerListener()::Duplicate Identify Response received from abis for same request id ::"
-									+ requestId + " response " + inserOrIdentifyResponse);
+					regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
+							registrationId,
+							"AbisMiddlewareStage::consumerListener()::Skipping IDENTIFY response because request status is not SENT. requestId="
+									+ requestId + ", currentStatus=" + abisCommonRequestDto.getStatusCode()
+									+ ", expectedStatus=" + AbisStatusCode.SENT.toString() + ", response="
+									+ inserOrIdentifyResponse);
 					isTransactionSuccessful = false;
 					description.setMessage(PlatformErrorMessages.DUPLICATE_IDENTITY_RESPONSE.getMessage() + requestId);
 					description.setCode(PlatformErrorMessages.DUPLICATE_IDENTITY_RESPONSE.getCode());
 
 				}
+			}
+			if (!abisCommonRequestDto.getRequestType().equals(AbisStatusCode.INSERT.toString())
+					&& !abisCommonRequestDto.getRequestType().equals(AbisStatusCode.IDENTIFY.toString())) {
+				regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
+						"AbisMiddlewareStage::consumerListener()::Skipping ABIS response because request type is unsupported. requestId="
+								+ requestId + ", requestType=" + abisCommonRequestDto.getRequestType()
+								+ ", statusCode=" + abisCommonRequestDto.getStatusCode() + ", response="
+								+ inserOrIdentifyResponse);
 			}
 
 		} catch (IOException e) {

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -144,6 +144,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 	@Value("${activemq.message.format}")
 	private String messageFormat;
 
+	/** Scheduled delivery delay for ABIS inbound queue messages (milliseconds). 0 = immediate. */
+	@Value("${mosip.regproc.abis.middleware.activemq.inbound.delay.ms:0}")
+	private long inboundMessageDelayMs;
+
 	/** The mosip event bus. */
 	MosipEventBus mosipEventBus = null;
 
@@ -610,18 +614,23 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 		regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
 				"AbisMiddlewareStage::sendToQueue()::Entry");
 		boolean isAddedToQueue;
+		long producerSubmitEpochMs = System.currentTimeMillis();
 		try {
 			synchronized (sendLock) {
 				if (messageFormat.equalsIgnoreCase(TEXT_MESSAGE))
 					isAddedToQueue = mosipQueueManager.send(queue, abisReqTextString,
-						abisQueueAddress, messageTTL);
+						abisQueueAddress, messageTTL, inboundMessageDelayMs);
 				else
 					isAddedToQueue = mosipQueueManager.send(queue, abisReqTextString.getBytes(),
-						abisQueueAddress, messageTTL);
+						abisQueueAddress, messageTTL, inboundMessageDelayMs);
 			}
 
-			regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
-					"AbisMiddlewareStage:: sent to abis queue ::" + abisReqTextString);
+			if (isAddedToQueue) {
+				regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
+						"AbisMiddlewareStage::sendToQueue::submitted queue=" + abisQueueAddress
+								+ " producerSubmitEpochMs=" + producerSubmitEpochMs + " configuredDelayMs="
+								+ inboundMessageDelayMs + " sent to abis queue ::" + abisReqTextString);
+			}
 
 		} catch (Exception e) {
 			regProcLogger.error(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.REGISTRATIONID.toString(),

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/test/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStageTest.java
@@ -3,6 +3,10 @@ package io.mosip.registartion.processor.abis.middleware.stage;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -184,6 +188,7 @@ public class AbisMiddleWareStageTest {
 		ReflectionTestUtils.setField(stage, "messageFormat", "byte");
 		ReflectionTestUtils.setField(stage, "defaultWorkerPoolSize", 10);
 		ReflectionTestUtils.setField(stage, "messageExpiryTimeLimit", Long.valueOf(0));
+		ReflectionTestUtils.setField(stage, "inboundMessageDelayMs", 500L);
 		ReflectionTestUtils.setField(stage, "clusterManagerUrl", "/dummyPath");
 		InternalRegistrationStatusDto internalRegStatusDto = new InternalRegistrationStatusDto();
 		internalRegStatusDto.setRegistrationId("");
@@ -328,6 +333,11 @@ public class AbisMiddleWareStageTest {
 		messageTTL = 30 * 60;
 
 		Mockito.when(propertiesUtil.getProperty(any(), any(Class.class), anyBoolean())).thenReturn(true);
+
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.any(byte[].class), Mockito.anyString(), anyInt(),
+				anyLong())).thenReturn(true);
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.anyString(), anyInt(), anyLong()))
+				.thenReturn(true);
 	}
 
 	@Test
@@ -336,7 +346,6 @@ public class AbisMiddleWareStageTest {
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
 
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(true);
 		MessageDTO dto = new MessageDTO();
 		dto.setRid("10003100030001520190422074511");
 		dto.setWorkflowInstanceId("workflowInstanceId");
@@ -345,6 +354,8 @@ public class AbisMiddleWareStageTest {
 		stage.deployVerticle();
 		stage.process(dto);
 		assertTrue(dto.getIsValid());
+		verify(mosipQueueManager, Mockito.atLeastOnce()).send(Mockito.any(), Mockito.any(byte[].class),
+				Mockito.anyString(), anyInt(), eq(500L));
 
 		// test for insert request list is empty
 		List<AbisRequestDto> abisInsertIdentifyList = new ArrayList<>();
@@ -368,7 +379,7 @@ public class AbisMiddleWareStageTest {
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
 
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.anyString(), anyInt(), anyLong()))
 				.thenThrow(ConnectionUnavailableException.class);
 		MessageDTO dto = new MessageDTO();
 		dto.setRid("10003100030001520190422074511");
@@ -388,7 +399,7 @@ public class AbisMiddleWareStageTest {
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
 
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt()))
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.anyString(), anyInt(), anyLong()))
 		.thenReturn(true);
 		MessageDTO dto = new MessageDTO();
 		dto.setRid("10003100030001520190422074511");
@@ -405,7 +416,6 @@ public class AbisMiddleWareStageTest {
 		// Mockito.when(utility.getMosipQueuesForAbis()).thenReturn(mosipQueueList);
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(true);
 		MessageDTO dto = new MessageDTO();
 		dto.setRid("10003100030001520190422074511");
 		Mockito.when(packetInfoManager.getReferenceIdByWorkflowInstanceId(Mockito.anyString())).thenReturn(null);
@@ -435,7 +445,8 @@ public class AbisMiddleWareStageTest {
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
 		Mockito.when(packetInfoManager.getReferenceIdByWorkflowInstanceId(Mockito.anyString())).thenReturn(abisRefList);
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(false);
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.any(byte[].class), Mockito.anyString(), anyInt(),
+				anyLong())).thenReturn(false);
 		stage.process(dto);
 
 		// test for exception while sending to queue
@@ -443,8 +454,8 @@ public class AbisMiddleWareStageTest {
 		Mockito.when(packetInfoManager.getInsertOrIdentifyRequest(Mockito.anyString(), Mockito.anyString()))
 				.thenReturn(abisInsertIdentifyList);
 		Mockito.when(packetInfoManager.getReferenceIdByWorkflowInstanceId(Mockito.anyString())).thenReturn(abisRefList);
-		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.anyString(), Mockito.any()))
-				.thenThrow(new NullPointerException());
+		Mockito.when(mosipQueueManager.send(Mockito.any(), Mockito.any(byte[].class), Mockito.anyString(), anyInt(),
+				anyLong())).thenThrow(new NullPointerException());
 		stage.process(dto);
 		assertTrue(dto.getIsValid());
 

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/queue/impl/MosipActiveMqImpl.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/queue/impl/MosipActiveMqImpl.java
@@ -14,6 +14,7 @@ import io.mosip.registration.processor.core.queue.impl.exception.QueueConnection
 import io.mosip.registration.processor.core.spi.queue.MosipQueueManager;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ScheduledMessage;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -21,6 +22,7 @@ import jakarta.jms.BytesMessage;
 import jakarta.jms.Connection;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
@@ -117,8 +119,13 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
      * lang.Object, java.lang.Object, java.lang.String, long)
      */
     @Override
-	@SuppressWarnings({ "java:S2095" })
     public Boolean send(MosipQueue mosipQueue, byte[] message, String address, int messageTTL) {
+        return send(mosipQueue, message, address, messageTTL, 0L);
+    }
+
+    @Override
+	@SuppressWarnings({ "java:S2095" })
+    public Boolean send(MosipQueue mosipQueue, byte[] message, String address, int messageTTL, long scheduledDelayMs) {
         regProcLogger.debug(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(),
                 "", "MosipActiveMqImpl::send()::entry");
 
@@ -129,8 +136,9 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
             MessageProducer messageProducer = sessionForSend.createProducer(sendDestination);
             BytesMessage byteMessage = sessionForSend.createBytesMessage();
             byteMessage.writeObject(message);
-            if(messageTTL > 0)
-                messageProducer.setTimeToLive(messageTTL * (long)1000);
+            applyScheduledDelay(byteMessage, scheduledDelayMs, address);
+            if (messageTTL > 0)
+                messageProducer.setTimeToLive(messageTTL * (long) 1000);
             messageProducer.send(byteMessage);
             flag = true;
         } catch (JMSException e) {
@@ -154,8 +162,13 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
     }
 
     @Override
-	@SuppressWarnings({ "java:S2095" })
     public Boolean send(MosipQueue mosipQueue, String message, String address, int messageTTL) {
+        return send(mosipQueue, message, address, messageTTL, 0L);
+    }
+
+    @Override
+	@SuppressWarnings({ "java:S2095" })
+    public Boolean send(MosipQueue mosipQueue, String message, String address, int messageTTL, long scheduledDelayMs) {
         boolean flag = false;
         initialSetup(mosipQueue);
         try {
@@ -168,8 +181,9 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
             MessageProducer messageProducer = sessionForSend.createProducer(sendDestination);
             TextMessage textMessage = sessionForSend.createTextMessage();
             textMessage.setText(message);
-            if(messageTTL > 0)
-                messageProducer.setTimeToLive(messageTTL * (long)1000);
+            applyScheduledDelay(textMessage, scheduledDelayMs, address);
+            if (messageTTL > 0)
+                messageProducer.setTimeToLive(messageTTL * (long) 1000);
             messageProducer.send(textMessage);
             flag = true;
         } catch (JMSException e) {
@@ -185,6 +199,14 @@ public class MosipActiveMqImpl implements MosipQueueManager<MosipQueue, byte[]> 
                 "", "MosipActiveMqImpl::send()::exit");
 
         return flag;
+    }
+
+    private void applyScheduledDelay(Message message, long scheduledDelayMs, String address) throws JMSException {
+        if (scheduledDelayMs > 0) {
+            message.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, scheduledDelayMs);
+            regProcLogger.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.USERID.toString(), "",
+                    "MosipActiveMqImpl::send()::scheduled queue=" + address + " scheduledDelayMs=" + scheduledDelayMs);
+        }
     }
 
     /*

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/queue/MosipQueueManager.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/spi/queue/MosipQueueManager.java
@@ -32,6 +32,18 @@ public interface MosipQueueManager<T, V>{
 	public Boolean send(T mosipQueue, V message, String address, int messageTTL);
 
 	/**
+	 * This method sends a message on a given Address with TTL and optional scheduled delay.
+	 *
+	 * @param mosipQueue       The mosipQueue instance
+	 * @param message          The message
+	 * @param address          The address
+	 * @param messageTTL       The timeToLive in seconds for message
+	 * @param scheduledDelayMs ActiveMQ scheduled delivery delay in milliseconds (0 = immediate)
+	 * @return True if message is sent, false otherwise
+	 */
+	public Boolean send(T mosipQueue, V message, String address, int messageTTL, long scheduledDelayMs);
+
+	/**
 	 * This method sends a json string message on a given Address
 	 *
 	 * @param mosipQueue The mosipQueue instance
@@ -51,6 +63,18 @@ public interface MosipQueueManager<T, V>{
 	 * @return True if message is sent, false otherwise
 	 */
 	public Boolean send(T mosipQueue, String message, String address, int messageTTL);
+
+	/**
+	 * This method sends a json string message on a given Address with TTL and optional scheduled delay.
+	 *
+	 * @param mosipQueue       The mosipQueue instance
+	 * @param message          The message
+	 * @param address          The address
+	 * @param messageTTL       The timeToLive in seconds for message
+	 * @param scheduledDelayMs ActiveMQ scheduled delivery delay in milliseconds (0 = immediate)
+	 * @return True if message is sent, false otherwise
+	 */
+	public Boolean send(T mosipQueue, String message, String address, int messageTTL, long scheduledDelayMs);
 
 	/**
 	 * This method consumes a message from a given address

--- a/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/queue/MosipActiveMqImplSendDelayTest.java
+++ b/registration-processor/registration-processor-core/src/test/java/io/mosip/registration/processor/queue/MosipActiveMqImplSendDelayTest.java
@@ -1,0 +1,45 @@
+package io.mosip.registration.processor.queue;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.apache.activemq.ScheduledMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.mosip.registration.processor.core.queue.impl.MosipActiveMqImpl;
+import jakarta.jms.JMSException;
+import jakarta.jms.TextMessage;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MosipActiveMqImplSendDelayTest {
+
+	@InjectMocks
+	private MosipActiveMqImpl mosipActiveMqImpl;
+
+	@Mock
+	private TextMessage textMessage;
+
+	@Test
+	public void applyScheduledDelaySetsAmqScheduledDelayProperty() throws JMSException {
+		ReflectionTestUtils.invokeMethod(mosipActiveMqImpl, "applyScheduledDelay", textMessage, 500L,
+				"abis-inbound-queue");
+
+		verify(textMessage).setLongProperty(eq(ScheduledMessage.AMQ_SCHEDULED_DELAY), eq(500L));
+	}
+
+	@Test
+	public void applyZeroDelaySkipsScheduledProperty() throws JMSException {
+		ReflectionTestUtils.invokeMethod(mosipActiveMqImpl, "applyScheduledDelay", textMessage, 0L,
+				"abis-inbound-queue");
+
+		verify(textMessage, never()).setLongProperty(eq(ScheduledMessage.AMQ_SCHEDULED_DELAY), anyLong());
+	}
+
+}


### PR DESCRIPTION
Adding support for scheduled delay in ABIS middleware while sending the message to ABIS to simulate the real time behavior