### PR TITLE
github-issue#2377

### DIFF
--- a/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-handler-stage/src/main/java/io/mosip/registration/processor/abis/handler/stage/AbisHandlerStage.java
@@ -220,9 +220,10 @@ public class AbisHandlerStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.ABIS_HANDLER_BUS_IN,
-				MessageBusAddress.ABIS_HANDLER_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.ABIS_HANDLER_BUS_IN,
+				MessageBusAddress.ABIS_HANDLER_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
+++ b/registration-processor/core-processor/registration-processor-abis-middleware-stage/src/main/java/io/mosip/registartion/processor/abis/middleware/stage/AbisMiddleWareStage.java
@@ -220,9 +220,10 @@ public class AbisMiddleWareStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.ABIS_MIDDLEWARE_BUS_IN,
-				MessageBusAddress.ABIS_MIDDLEWARE_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.ABIS_MIDDLEWARE_BUS_IN,
+				MessageBusAddress.ABIS_MIDDLEWARE_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 
 	}
 

--- a/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-bio-dedupe-stage/src/main/java/io/mosip/registration/processor/biodedupe/stage/BioDedupeStage.java
@@ -65,8 +65,9 @@ public class BioDedupeStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.BIO_DEDUPE_BUS_IN, MessageBusAddress.BIO_DEDUPE_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.BIO_DEDUPE_BUS_IN, MessageBusAddress.BIO_DEDUPE_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 	
 	@Override

--- a/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
+++ b/registration-processor/core-processor/registration-processor-biometric-authentication-stage/src/main/java/io/mosip/registration/processor/biometric/authentication/stage/BiometricAuthenticationStage.java
@@ -120,9 +120,10 @@ public class BiometricAuthenticationStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_IN,
-				MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_IN,
+				MessageBusAddress.BIOMETRIC_AUTHENTICATION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/main/java/io/mosip/registration/processor/stages/biometric/extraction/stage/BiometricExtractionStage.java
+++ b/registration-processor/core-processor/registration-processor-biometric-extraction-stage/src/main/java/io/mosip/registration/processor/stages/biometric/extraction/stage/BiometricExtractionStage.java
@@ -138,9 +138,10 @@ public class BiometricExtractionStage extends MosipVerticleAPIManager{
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_IN,
-				MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_IN,
+				MessageBusAddress.BIOMETRIC_EXTRACTION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 
 	}
 	/*

--- a/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
+++ b/registration-processor/core-processor/registration-processor-demo-dedupe-stage/src/main/java/io/mosip/registration/processor/stages/demodedupe/DemoDedupeStage.java
@@ -61,8 +61,9 @@ public class DemoDedupeStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.DEMO_DEDUPE_BUS_IN, MessageBusAddress.DEMO_DEDUPE_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.DEMO_DEDUPE_BUS_IN, MessageBusAddress.DEMO_DEDUPE_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 	
 	@Override

--- a/registration-processor/core-processor/registration-processor-finalization-stage/src/main/java/io/mosip/registration/processor/stages/finalization/stage/FinalizationStage.java
+++ b/registration-processor/core-processor/registration-processor-finalization-stage/src/main/java/io/mosip/registration/processor/stages/finalization/stage/FinalizationStage.java
@@ -110,9 +110,10 @@ public class FinalizationStage extends MosipVerticleAPIManager{
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.FINALIZATION_BUS_IN,
-				MessageBusAddress.FINALIZATION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.FINALIZATION_BUS_IN,
+				MessageBusAddress.FINALIZATION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 
 	}
 	/*

--- a/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/main/java/io/mosip/registration/processor/adjudication/stage/ManualAdjudicationStage.java
+++ b/registration-processor/core-processor/registration-processor-manual-adjudication-stage/src/main/java/io/mosip/registration/processor/adjudication/stage/ManualAdjudicationStage.java
@@ -175,8 +175,9 @@ public class ManualAdjudicationStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.MANUAL_ADJUDICATION_BUS_IN, MessageBusAddress.MANUAL_ADJUDICATION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.MANUAL_ADJUDICATION_BUS_IN, MessageBusAddress.MANUAL_ADJUDICATION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
+++ b/registration-processor/core-processor/registration-processor-uin-generator-stage/src/main/java/io/mosip/registration/processor/stages/uingenerator/stage/UinGeneratorStage.java
@@ -1100,9 +1100,10 @@ public class UinGeneratorStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.UIN_GENERATION_BUS_IN,
-				MessageBusAddress.UIN_GENERATION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.UIN_GENERATION_BUS_IN,
+				MessageBusAddress.UIN_GENERATION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 
 	}
 

--- a/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
+++ b/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
@@ -176,8 +176,9 @@ public class VerificationStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.MANUAL_ADJUDICATION_BUS_IN, MessageBusAddress.MANUAL_ADJUDICATION_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.MANUAL_ADJUDICATION_BUS_IN, MessageBusAddress.MANUAL_ADJUDICATION_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
+++ b/registration-processor/core-processor/registration-processor-verification-stage/src/main/java/io/mosip/registration/processor/verification/stage/VerificationStage.java
@@ -9,7 +9,6 @@ import org.apache.activemq.command.ActiveMQBytesMessage;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -48,7 +47,6 @@ import io.mosip.registration.processor.verification.util.ManualVerificationReque
  * @author Pranav Kumar
  * @since 0.0.1
  */
-@RefreshScope
 @Service
 @Configuration
 @ComponentScan(basePackages = { "${mosip.auth.adapter.impl.basepackage}",

--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
@@ -112,7 +112,7 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	public void start() {
 		io.vertx.ext.web.Router vertxRouter = this.postUrl(vertx, null, MessageBusAddress.PACKET_RECEIVER_OUT);
 		router.setRoute(vertxRouter);
-		this.routes(router, vertxRouter);
+		this.routes(router);
 		this.createServer(vertxRouter, getPort());
 	}
 
@@ -121,11 +121,9 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	 *
 	 * @param router
 	 *            the router
-	 * @param vertxRouter
-	 *            the vertx router
 	 */
-	private void routes(MosipRouter router, io.vertx.ext.web.Router vertxRouter) {
-		router.post(vertxRouter, getServletPath() + "/registrationpackets");
+	private void routes(MosipRouter router) {
+		router.post(getServletPath() + "/registrationpackets");
 		router.handler(this::processURL, this::processPacket, this::failure);
 	}
 

--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
@@ -112,9 +112,10 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	 */
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(vertx, null, MessageBusAddress.PACKET_RECEIVER_OUT));
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(vertx, null, MessageBusAddress.PACKET_RECEIVER_OUT);
+		router.setRoute(vertxRouter);
 		this.routes(router);
-		this.createServer(router.getRouter(), getPort());
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/**

--- a/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
+++ b/registration-processor/init/registration-processor-packet-receiver-stage/src/main/java/io/mosip/registration/processor/packet/receiver/stage/PacketReceiverStage.java
@@ -12,7 +12,6 @@ import io.mosip.kernel.core.util.DateUtils2;
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -42,7 +41,6 @@ import io.vertx.ext.web.RoutingContext;
  * The Class PacketReceiverStage.
  */
 
-@RefreshScope
 @Service
 @Configuration
 @ComponentScan(basePackages = { "${mosip.auth.adapter.impl.basepackage}",
@@ -114,7 +112,7 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	public void start() {
 		io.vertx.ext.web.Router vertxRouter = this.postUrl(vertx, null, MessageBusAddress.PACKET_RECEIVER_OUT);
 		router.setRoute(vertxRouter);
-		this.routes(router);
+		this.routes(router, vertxRouter);
 		this.createServer(vertxRouter, getPort());
 	}
 
@@ -123,12 +121,13 @@ public class PacketReceiverStage extends MosipVerticleAPIManager {
 	 *
 	 * @param router
 	 *            the router
+	 * @param vertxRouter
+	 *            the vertx router
 	 */
-	private void routes(MosipRouter router) {
-
-		router.post(getServletPath() + "/registrationpackets");
+	private void routes(MosipRouter router, io.vertx.ext.web.Router vertxRouter) {
+		router.post(vertxRouter, getServletPath() + "/registrationpackets");
 		router.handler(this::processURL, this::processPacket, this::failure);
-	};
+	}
 
 	/**
 	 * This is for failure handler.

--- a/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
+++ b/registration-processor/post-processor/registration-processor-credential-requestor-stage/src/main/java/io/mosip/registration/processor/credentialrequestor/stage/CredentialRequestorStage.java
@@ -397,9 +397,10 @@ public class CredentialRequestorStage extends MosipVerticleAPIManager {
 	 */
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), 
-				MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(),
+				MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_IN, MessageBusAddress.CREDENTIAL_REQUESTOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	public String generatePin() {

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
@@ -11,7 +11,6 @@ import org.json.JSONException;
 import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -84,8 +83,6 @@ import io.mosip.registration.processor.status.service.TransactionService;
  * @author M1048358 Alok
  * @since 1.0.0
  */
-@RefreshScope
-
 @Service
 @Configuration
 @ComponentScan(basePackages = { "${mosip.auth.adapter.impl.basepackage}",

--- a/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
+++ b/registration-processor/post-processor/registration-processor-message-sender-stage/src/main/java/io/mosip/registration/processor/message/sender/stage/MessageSenderStage.java
@@ -184,8 +184,9 @@ public class MessageSenderStage extends MosipVerticleAPIManager {
 	 */
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(vertx, MessageBusAddress.MESSAGE_SENDER_BUS, null));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(vertx, MessageBusAddress.MESSAGE_SENDER_BUS, null);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/*

--- a/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/main/java/io/mosip/registration/processor/stages/app/CMDValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-cmd-validator-stage/src/main/java/io/mosip/registration/processor/stages/app/CMDValidatorStage.java
@@ -50,9 +50,10 @@ public class CMDValidatorStage extends MosipVerticleAPIManager {
 	
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(), 
-			MessageBusAddress.CMD_VALIDATOR_BUS_IN, MessageBusAddress.CMD_VALIDATOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(),
+			MessageBusAddress.CMD_VALIDATOR_BUS_IN, MessageBusAddress.CMD_VALIDATOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	

--- a/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/main/java/io/mosip/registration/processor/stages/introducervalidator/IntroducerValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-introducer-validator-stage/src/main/java/io/mosip/registration/processor/stages/introducervalidator/IntroducerValidatorStage.java
@@ -56,9 +56,10 @@ public class IntroducerValidatorStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.INTRODUCER_VALIDATOR_BUS_IN,
-				MessageBusAddress.INTRODUCER_VALIDATOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.INTRODUCER_VALIDATOR_BUS_IN,
+				MessageBusAddress.INTRODUCER_VALIDATOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/main/java/io/mosip/registration/processor/stages/operatorvalidator/OperatorValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-operator-validator-stage/src/main/java/io/mosip/registration/processor/stages/operatorvalidator/OperatorValidatorStage.java
@@ -55,9 +55,10 @@ public class OperatorValidatorStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.OPERATOR_VALIDATOR_BUS_IN,
-				MessageBusAddress.OPERATOR_VALIDATOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.OPERATOR_VALIDATOR_BUS_IN,
+				MessageBusAddress.OPERATOR_VALIDATOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/config/PacketClassifierConfig.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/config/PacketClassifierConfig.java
@@ -1,6 +1,5 @@
 package io.mosip.registration.processor.stages.config;
 
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,7 +13,6 @@ import io.mosip.registration.processor.stages.packetclassifier.utility.PacketCla
  * The beans belonging to other libraries has their own config class to declare the required beans
  */
 @Configuration
-@RefreshScope
 public class PacketClassifierConfig {
 
 	@Bean

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
@@ -2,7 +2,6 @@ package io.mosip.registration.processor.stages.packetclassifier;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
@@ -19,7 +18,6 @@ import io.mosip.registration.processor.core.abstractverticle.MosipVerticleAPIMan
  *
  * @author Vishwanath V
  */
-@RefreshScope
 @Service
 @Configuration
 @ComponentScan(basePackages = { "${mosip.auth.adapter.impl.basepackage}",

--- a/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-classifier-stage/src/main/java/io/mosip/registration/processor/stages/packetclassifier/PacketClassifierStage.java
@@ -69,9 +69,10 @@ public class PacketClassifierStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(),
-			MessageBusAddress.PACKET_CLASSIFIER_BUS_IN, MessageBusAddress.PACKET_CLASSIFIER_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(),
+			MessageBusAddress.PACKET_CLASSIFIER_BUS_IN, MessageBusAddress.PACKET_CLASSIFIER_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/*

--- a/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-uploader-stage/src/main/java/io/mosip/registration/processor/packet/uploader/stage/PacketUploaderStage.java
@@ -79,9 +79,10 @@ public class PacketUploaderStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.PACKET_UPLOADER_IN,
-				MessageBusAddress.PACKET_UPLOADER_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.PACKET_UPLOADER_IN,
+				MessageBusAddress.PACKET_UPLOADER_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/*

--- a/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-packet-validator-stage/src/main/java/io/mosip/registration/processor/stages/packet/validator/PacketValidatorStage.java
@@ -69,9 +69,10 @@ public class PacketValidatorStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start(){
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.PACKET_VALIDATOR_BUS_IN,
-				MessageBusAddress.PACKET_VALIDATOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.PACKET_VALIDATOR_BUS_IN,
+				MessageBusAddress.PACKET_VALIDATOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 	/*
 	 * (non-Javadoc)

--- a/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/main/java/io/mosip/registration/processor/quality/classifier/stage/QualityClassifierStage.java
+++ b/registration-processor/pre-processor/registration-processor-quality-classifier-stage/src/main/java/io/mosip/registration/processor/quality/classifier/stage/QualityClassifierStage.java
@@ -208,9 +208,10 @@ public class QualityClassifierStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.QUALITY_CLASSIFIER_BUS_IN,
-				MessageBusAddress.QUALITY_CLASSIFIER_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.QUALITY_CLASSIFIER_BUS_IN,
+				MessageBusAddress.QUALITY_CLASSIFIER_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/*

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -129,7 +129,7 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
 				MessageBusAddress.SECUREZONE_NOTIFICATION_OUT);
 		router.setRoute(vertxRouter);
-		this.routes(router, vertxRouter);
+		this.routes(router);
 		this.createServer(vertxRouter, getPort());
 	}
 
@@ -137,10 +137,9 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 	 * contains all the routes in this stage
 	 *
 	 * @param router
-	 * @param vertxRouter
 	 */
-	private void routes(MosipRouter router, io.vertx.ext.web.Router vertxRouter) {
-		router.post(vertxRouter, getServletPath() + "/notification");
+	private void routes(MosipRouter router) {
+		router.post(getServletPath() + "/notification");
 		router.handler(this::processURL, this::failure);
 	}
 

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -129,7 +129,7 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
 				MessageBusAddress.SECUREZONE_NOTIFICATION_OUT);
 		router.setRoute(vertxRouter);
-		this.routes(router);
+		this.routes(router, vertxRouter);
 		this.createServer(vertxRouter, getPort());
 	}
 
@@ -137,9 +137,10 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 	 * contains all the routes in this stage
 	 *
 	 * @param router
+	 * @param vertxRouter
 	 */
-	private void routes(MosipRouter router) {
-		router.post(getServletPath() + "/notification");
+	private void routes(MosipRouter router, io.vertx.ext.web.Router vertxRouter) {
+		router.post(vertxRouter, getServletPath() + "/notification");
 		router.handler(this::processURL, this::failure);
 	}
 

--- a/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
+++ b/registration-processor/pre-processor/registration-processor-securezone-notification-stage/src/main/java/io/mosip/registration/processor/securezone/notification/stage/SecurezoneNotificationStage.java
@@ -126,10 +126,11 @@ public class SecurezoneNotificationStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
-				MessageBusAddress.SECUREZONE_NOTIFICATION_OUT));
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.SECUREZONE_NOTIFICATION_IN,
+				MessageBusAddress.SECUREZONE_NOTIFICATION_OUT);
+		router.setRoute(vertxRouter);
 		this.routes(router);
-		this.createServer(router.getRouter(), getPort());
+		this.createServer(vertxRouter, getPort());
 	}
 
 	/**

--- a/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/main/java/io/mosip/registration/processor/stages/supervisorvalidator/SupervisorValidatorStage.java
+++ b/registration-processor/pre-processor/registration-processor-supervisor-validator-stage/src/main/java/io/mosip/registration/processor/stages/supervisorvalidator/SupervisorValidatorStage.java
@@ -55,9 +55,10 @@ public class SupervisorValidatorStage extends MosipVerticleAPIManager {
 
 	@Override
 	public void start() {
-		router.setRoute(this.postUrl(getVertx(), MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_IN,
-				MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_OUT));
-		this.createServer(router.getRouter(), getPort());
+		io.vertx.ext.web.Router vertxRouter = this.postUrl(getVertx(), MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_IN,
+				MessageBusAddress.SUPERVISOR_VALIDATOR_BUS_OUT);
+		router.setRoute(vertxRouter);
+		this.createServer(vertxRouter, getPort());
 	}
 
 	@Override

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipRouter.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipRouter.java
@@ -58,11 +58,6 @@ public class MosipRouter {
 		return this.route;
 	}
 
-	public Route post(Router specificRouter, String url) {
-		this.route = specificRouter.post(url);
-		return this.route;
-	}
-
 	/**
 	 * this method is used to handle request and failure handler including
 	 * validation of token

--- a/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipRouter.java
+++ b/registration-processor/registration-processor-core/src/main/java/io/mosip/registration/processor/core/abstractverticle/MosipRouter.java
@@ -58,6 +58,11 @@ public class MosipRouter {
 		return this.route;
 	}
 
+	public Route post(Router specificRouter, String url) {
+		this.route = specificRouter.post(url);
+		return this.route;
+	}
+
 	/**
 	 * this method is used to handle request and failure handler including
 	 * validation of token


### PR DESCRIPTION
 ---
  Problem 1 — Slow Startup (@RefreshScope)

  MessageSenderStage had @RefreshScope alongside @Service and @Configuration. This made Spring defer the actual bean initialization (including scanning 8+ component packages) until first use on the Vert.x
  event loop thread. That blocked the event loop during Vert.x deployment, making all three stages slow to start — taking 3–4 minutes instead of under a minute.

  Impact: Kubernetes initialDelaySeconds was tight. The slow startup was pushing readiness probe responses past the deadline, triggering pod restarts before the application was even ready.

  Fix: Removed @RefreshScope from MessageSenderStage. Spring now eagerly initializes the bean during context startup. All three stages are up and ready in ~43 seconds.

  ---
  Problem 2 — Health Check 404s (MosipRouter Race Condition)

  MosipRouter is a Spring @Component singleton — one shared instance for the entire JVM. All three stages @Autowired the same bean and their start() methods ran concurrently (each stage on its own Vert.x
  event loop thread).

  Every stage's start() followed this pattern:
  router.setRoute(this.postUrl(...))   // writes THIS stage's router into the shared singleton
  this.createServer(router.getRouter(), getPort())  // reads WHOEVER's router is there NOW

  With concurrent execution, a stage could write its router into the singleton and then read back a different stage's router (written by another thread in between). That stage's HTTP server then started with
  the wrong Vert.x Router — one that didn't have its health endpoint path registered. Kubernetes liveness probes hitting that port got 404, failed repeatedly, and killed the pod.

  This explained why the failure was non-deterministic: log 1 showed securezone healthy but quality-classifier failing; log 2 (after restart) showed securezone failing too. Thread scheduling determined the
  winner each time.

  Fix: In each stage's start(), the Vert.x Router returned by postUrl() is captured in a local variable and passed directly to createServer():

  // Before — race window between these two lines:
  router.setRoute(this.postUrl(...));
  this.createServer(router.getRouter(), getPort());

  // After — no race; same object used end-to-end:
  io.vertx.ext.web.Router vertxRouter = this.postUrl(...);
  router.setRoute(vertxRouter);
  this.createServer(vertxRouter, getPort());

  The health endpoint is registered inside postUrl() on vertxRouter. Passing vertxRouter directly to createServer() guarantees each stage's HTTP server always has its own correct health routes — regardless of
   what other threads do to the shared MosipRouter singleton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized HTTP server/router startup wiring across multiple registration processing stages to use a single, consistent router instance during endpoint initialization.
  * Updated routing registration to pass the same router used to start the server, improving overall consistency.

* **Configuration**
  * Removed runtime refresh scoping from several processing stages and one configuration component, with no expected endpoint behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->